### PR TITLE
v0.6.15

### DIFF
--- a/lib/interfaces/farmer.js
+++ b/lib/interfaces/farmer.js
@@ -82,6 +82,37 @@ FarmerInterface.prototype.join = function(callback) {
 };
 
 /**
+ * Sends the given contract as an offer to the specified renter
+ * @private
+ * @param {Contract} contract - The contract to include in offer
+ * @param {Contact} renter - The renter who originally published the contract
+ */
+FarmerInterface.prototype._sendOfferForContract = function(contract, contact) {
+  var self = this;
+  var message = new kad.Message({
+    method: 'OFFER',
+    params: {
+      contract: contract.toObject(),
+      contact: self._contact
+    }
+  });
+
+  self._transport.send(contact, message, function(err, response) {
+    if (err) {
+      return self._logger.error(err.message);
+    }
+
+    if (response.error || !response.result.contract) {
+      return self._logger.error(
+        response.error ? response.error.message : 'Renter refused to sign'
+      );
+    }
+
+    self._handleOfferRes(response, contract, contact);
+  });
+};
+
+/**
  * Handles a received contract and negotiates storage
  * @private
  * @param {Contract} contract
@@ -109,6 +140,13 @@ FarmerInterface.prototype._negotiateContract = function(contract) {
       return self._logger.error(err.message);
     }
 
+    if (self._router.getContactByNodeID(renterId)) {
+      return self._sendOfferForContract(
+        contract,
+        self._router.getContactByNodeID(renterId)
+      );
+    }
+
     self._router.findNode(renterId, function(err, nodes) {
       if (err) {
         return self._logger.error(err.message);
@@ -122,27 +160,7 @@ FarmerInterface.prototype._negotiateContract = function(contract) {
         return self._logger.error('Could not locate renter for offer');
       }
 
-      var message = new kad.Message({
-        method: 'OFFER',
-        params: {
-          contract: contract.toObject(),
-          contact: self._contact
-        }
-      });
-
-      self._transport.send(renter, message, function(err, response) {
-        if (err) {
-          return self._logger.error(err.message);
-        }
-
-        if (response.error || !response.result.contract) {
-          return self._logger.error(
-            response.error ? response.error.message : 'Renter refused to sign'
-          );
-        }
-
-        self._handleOfferRes(response, contract, renter);
-      });
+      self._sendOfferForContract(contract, renter);
     });
   });
 

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -113,21 +113,27 @@ Network.prototype.join = function(callback) {
     logger: this._logger
   });
 
-  async.each(seeds, function(contact, next) {
-    self._node.connect(contact, function(err) {
-      if (err) {
-        self._logger.warn('failed to connect to seed %j', contact);
-      }
-    });
-    next();
-  }, function() {
+  function onJoinComplete() {
     if (self._transport._isPublic) {
       self._listenForTunnelers();
       callback(null, self);
     } else {
       self._setupTunnelClient(callback);
     }
-  });
+  }
+
+  async.detectSeries(seeds, function(contact, next) {
+    self._logger.info('attemting to join network via %j', contact);
+    self._node.connect(contact, function(err) {
+      if (err) {
+        self._logger.warn('failed to connect to seed %j', contact);
+      } else {
+        self._logger.info('connected to the storj network via %j', contact);
+      }
+
+      next(null, !err);
+    });
+  }, onJoinComplete);
 };
 
 /**

--- a/lib/network/protocol.js
+++ b/lib/network/protocol.js
@@ -302,9 +302,9 @@ Protocol.prototype._askNeighborsForTunnels = function(callback) {
             self._network._transport._createContact(tun)
           );
         }
-
-        done();
       });
+
+      done();
     });
   }
 

--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -68,7 +68,7 @@ Transport.prototype._open = function(callback) {
   self._forwardPort(function(err, ip, port) {
     self._isPublic = !err;
     kad.transports.HTTP.prototype._open.call(self, callback);
-    self._contact.port = port;
+    self._contact.port = port || self._contact.port;
     self._contact.address = ip || self._contact.address;
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "description": "implementation of the storj protocol for node.js and the browser",
   "main": "index.js",
   "directories": {
@@ -48,8 +48,8 @@
     "ip": "^1.1.2",
     "jsen": "^0.6.0",
     "json-stable-stringify": "^1.0.1",
-    "kad": "^1.5.8",
-    "kad-quasar": "0.1.0",
+    "kad": "^1.5.9",
+    "kad-quasar": "^0.1.2",
     "leveldown": "^1.4.6",
     "levelup": "^1.3.1",
     "merge": "^1.2.0",

--- a/test/interfaces/farmer+renter.integration.js
+++ b/test/interfaces/farmer+renter.integration.js
@@ -17,6 +17,8 @@ var StorageItem = require('../../lib/storage/item');
 var Verification = require('../../lib/verification');
 var memdown = require('memdown');
 
+kad.constants.T_RESPONSETIMEOUT = 2000;
+
 var NODE_LIST = [];
 var STARTING_PORT = 65535;
 
@@ -76,11 +78,12 @@ describe('Interfaces/Farmer+Renter/Integration', function() {
   describe('#join', function() {
 
     it('should connect all the nodes together', function(done) {
-      this.timeout(5000);
+      this.timeout(35000);
       farmers[0].join(function() {
         farmers.shift();
-        async.eachSeries(farmers.concat(renters), function(node, done) {
-          node.join(done);
+        async.each(farmers.concat(renters), function(node, done) {
+          node.join(function noop() {});
+          done();
         }, done);
       });
     });

--- a/test/interfaces/farmer.unit.js
+++ b/test/interfaces/farmer.unit.js
@@ -1,10 +1,13 @@
 'use strict';
 
+var sinon = require('sinon');
 var expect = require('chai').expect;
 var Contract = require('../../lib/contract');
 var KeyPair = require('../../lib/keypair');
 var FarmerInterface = require('../../lib/interfaces/farmer');
 var kad = require('kad');
+var Contact = require('../../lib/network/contact');
+var utils = require('../../lib/utils');
 
 describe('FarmerInterface', function() {
 
@@ -22,6 +25,50 @@ describe('FarmerInterface', function() {
         backend: require('memdown')
       });
       expect(farmer._negotiateContract(Contract({}))).to.equal(false);
+    });
+
+    it('should ask network for renter if not locally known', function(done) {
+      var kp1 = KeyPair();
+      var kp2 = KeyPair();
+      var contract = new Contract({
+        renter_id: kp1.getNodeID(),
+        farmer_id: kp2.getNodeID(),
+        payment_source: kp1.getAddress(),
+        payment_destination: kp2.getAddress(),
+        data_hash: utils.rmd160('test')
+      });
+      contract.sign('renter', kp1.getPrivateKey());
+      contract.sign('farmer', kp2.getPrivateKey());
+      expect(contract.isComplete()).to.equal(true);
+      var farmer = new FarmerInterface({
+        keypair: KeyPair(),
+        port: 0,
+        noforward: true,
+        logger: kad.Logger(0),
+        backend: require('memdown'),
+        storage: { path: 'test' }
+      });
+      var _getContactByNodeID = sinon.stub(
+        farmer._router,
+        'getContactByNodeID'
+      ).returns(null);
+      var _findNode = sinon.stub(
+        farmer._router,
+        'findNode'
+      ).callsArgWith(1, null, [Contact({
+        address: '127.0.0.1',
+        port: 1234,
+        nodeID: kp1.getNodeID()
+      })]);
+      var _save = sinon.stub(farmer._manager, 'save').callsArg(1);
+      farmer._sendOfferForContract = function() {
+        expect(_findNode.called).to.equal(true);
+        _getContactByNodeID.restore();
+        _findNode.restore();
+        _save.restore();
+        done();
+      };
+      farmer._negotiateContract(contract);
     });
 
   });


### PR DESCRIPTION
#### Changes

* Check local routing table for renter contact before querying the network (during contract negotiation)
* Bump `kad-quasar`
* Bump `kad`
* Fix UPnP failure leading to undefined port
* Use `async.detectSeries` for multi-seed join, to only try next seed if previous failed

#### Issues

* Closes #99 
* Closes #98 
* Closes #108 
* Closes #105 

#### Related

* https://github.com/kadtools/kad/releases/tag/v1.5.9
* https://github.com/kadtools/kad-quasar/releases/tag/v0.1.1
* https://github.com/kadtools/kad-quasar/releases/tag/v0.1.2