### PR TITLE
[CRITICAL] Fix value encoding of file shards (v0.6.16)

### DIFF
--- a/lib/storage/adapters/level/filestore.js
+++ b/lib/storage/adapters/level/filestore.js
@@ -66,13 +66,15 @@ LevelDBFileStore.prototype.createReadStream = function(key) {
     read: function() {
       var rs = this;
 
-      self._db.get(key + ' ' + index.toString(), function(err, result) {
+      self._db.get(key + ' ' + index.toString(), {
+        valueEncoding: 'binary'
+      }, function(err, result) {
         if (err) {
-          return rs.push(null);
-        }
-
-        if (result === 'null') { // NB: We store the string "null" to signal EOF
-          return rs.push(null);
+          if (err.type === 'NotFoundError') {
+            return rs.push(null);
+          } else {
+            return self.emit('error', err);
+          }
         }
 
         index++;
@@ -90,24 +92,10 @@ LevelDBFileStore.prototype.createReadStream = function(key) {
 LevelDBFileStore.prototype.createWriteStream = function(key) {
   var self = this;
   var index = 0;
-  var nullBound = false;
 
   return new stream.Writable({
     write: function(bytes, encoding, callback) {
       var ws = this;
-
-      if (!nullBound) {
-        ws.on('finish', function() {
-          var ws = this;
-
-          self._db.put(key + ' ' + index.toString(), null, function(err) {
-            if (err) {
-              return ws.emit('error', err);
-            }
-          });
-        });
-        nullBound = true;
-      }
 
       self._db.put(key + ' ' + index.toString(), bytes, function(err) {
         if (err) {

--- a/lib/storage/adapters/level/filestore.js
+++ b/lib/storage/adapters/level/filestore.js
@@ -76,9 +76,9 @@ LevelDBFileStore.prototype.createReadStream = function(key) {
             return self.emit('error', err);
           }
         }
-
+        
         index++;
-        rs.push(Buffer(result));
+        rs.push(Buffer(result, 'binary'));
       });
     }
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "description": "implementation of the storj protocol for node.js and the browser",
   "main": "index.js",
   "directories": {

--- a/test/storage/adapters/level.unit.js
+++ b/test/storage/adapters/level.unit.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var crypto = require('crypto');
 var memdown = require('memdown');
 var LevelDBStorageAdapter = require('../../../lib/storage/adapters/level');
+var LevelDBFileStore = require('../../../lib/storage/adapters/level/filestore');
 var StorageItem = require('../../../lib/storage/item');
 var expect = require('chai').expect;
 var utils = require('../../../lib/utils');
@@ -126,6 +128,109 @@ describe('LevelDBStorageAdapter', function() {
         expect(err).to.equal(null);
         done();
       });
+    });
+
+  });
+
+});
+
+describe('LevelDBFileStore', function() {
+
+  var store = new LevelDBStorageAdapter('filestore', memdown)._db;
+  var sample = crypto.randomBytes(8);
+
+  describe('@constructor', function() {
+
+    it('should create instance without the new keyword', function() {
+      expect(LevelDBFileStore(store)).to.be.instanceOf(LevelDBFileStore);
+    });
+
+    it('should create instance with the new keyword', function() {
+      expect(new LevelDBFileStore(store)).to.be.instanceOf(LevelDBFileStore);
+    });
+
+  });
+
+  describe('#createReadStream/#createWriteStream', function() {
+
+    it('should work with hex encoding', function(done) {
+      var data = Buffer(sample.toString('hex'), 'hex');
+      var fs = new LevelDBFileStore(store);
+      var ws = fs.createWriteStream('hex');
+      ws.on('finish', function() {
+        var result = Buffer([]);
+        var rs = fs.createReadStream('hex');
+        rs.on('data', function(data) {
+          result = Buffer.concat([result, data]);
+        }).on('end', function() {
+          expect(Buffer.compare(sample, result)).to.equal(0);
+          done();
+        });
+      }).end(data);
+    });
+
+    it('should work with base64 encoding', function(done) {
+      var data = Buffer(sample.toString('base64'), 'base64');
+      var fs = new LevelDBFileStore(store);
+      var ws = fs.createWriteStream('base64');
+      ws.on('finish', function() {
+        var result = Buffer([]);
+        var rs = fs.createReadStream('base64');
+        rs.on('data', function(data) {
+          result = Buffer.concat([result, data]);
+        }).on('end', function() {
+          expect(Buffer.compare(sample, result)).to.equal(0);
+          done();
+        });
+      }).end(data);
+    });
+
+    it('should work with utf8 encoding', function(done) {
+      var data = Buffer(sample);
+      var fs = new LevelDBFileStore(store);
+      var ws = fs.createWriteStream('utf8');
+      ws.on('finish', function() {
+        var result = Buffer([]);
+        var rs = fs.createReadStream('utf8');
+        rs.on('data', function(data) {
+          result = Buffer.concat([result, data]);
+        }).on('end', function() {
+          expect(Buffer.compare(sample, result)).to.equal(0);
+          done();
+        });
+      }).end(data);
+    });
+
+    it('should work with binary encoding', function(done) {
+      var data = Buffer(sample.toString('binary'), 'binary');
+      var fs = new LevelDBFileStore(store);
+      var ws = fs.createWriteStream('binary');
+      ws.on('finish', function() {
+        var result = Buffer([]);
+        var rs = fs.createReadStream('binary');
+        rs.on('data', function(data) {
+          result = Buffer.concat([result, data]);
+        }).on('end', function() {
+          expect(Buffer.compare(sample, result)).to.equal(0);
+          done();
+        });
+      }).end(data);
+    });
+
+    it('should work with utf16le encoding', function(done) {
+      var data = Buffer(sample.toString('utf16le'), 'utf16le');
+      var fs = new LevelDBFileStore(store);
+      var ws = fs.createWriteStream('utf16le');
+      ws.on('finish', function() {
+        var result = Buffer([]);
+        var rs = fs.createReadStream('utf16le');
+        rs.on('data', function(data) {
+          result = Buffer.concat([result, data]);
+        }).on('end', function() {
+          expect(Buffer.compare(sample, result)).to.equal(0);
+          done();
+        });
+      }).end(data);
     });
 
   });


### PR DESCRIPTION
Since the last update to the storage adapter (`LevelDBStorageAdapter`), shards have been stored with `utf8` character encoding by default by the `levelup` library used to interface with LevelDB. This spells doom for images, videos, and other binary data that is not `utf8` encoded and results in incorrect data being stored and returned.

This PR forces the adapter to store all shards with binary (`latin-1`) encoding.