### PR TITLE
npm list -g storj

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,16 +1,17 @@
 ### Package Versions
 
-Replace the values below using the output from `npm list storj`.
+Replace the values below using the output from `npm list -g storj`.
 
 ```
-storj-bridge@0.6.5 /home/gordon/Code/storj-bridge
-└── storj@0.6.5  -> /home/gordon/Code/storj-core
+/usr/local/lib
+└─┬ storjshare-cli@3.0.5
+  └── storj@0.6.16
 ```
 
 Replace the values below using the output from `node --version`.
 
 ```
-v4.2.3
+v4.4.4
 ```
 
 ### Expected Behavior


### PR DESCRIPTION
https://github.com/Storj/storjshare-cli#installation
`npm install -g storjshare-cli` -> `npm list storj` will find nothing. This pull request will change it into `npm list -g storj`