### PR TITLE
v1.2.3

### DIFF
--- a/lib/bridgeclient.js
+++ b/lib/bridgeclient.js
@@ -101,6 +101,19 @@ BridgeClient.prototype.createUser = function(options, callback) {
 };
 
 /**
+ * Deactivates a user account
+ * @param {Object} options
+ * @param {String} options.email - Email address of user to deactivate
+ * @param {String} options.redirect - URL to redirect after verification
+ * @param {Function} callback
+ */
+BridgeClient.prototype.destroyUser = function(options, callback) {
+  return this._request('DELETE', '/users/' + options.email, {
+    redirect: options.redirect
+  }, callback);
+};
+
+/**
  * Returns list of associated public keys
  * @param {Function} callback
  */

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -64,8 +64,15 @@ function Network(options) {
 inherits(Network, EventEmitter);
 
 /**
- * Ready event is triggered when the transport's network interface is ready
+ * Triggered when the transport's network interface is ready
  * @event Network#ready
+ */
+
+/**
+ * Triggered when a valid offer is received, but we are not waiting for one
+ * @event Network#unhandledOffer
+ * @param {Contract} contract - The complete contract, signed by us and farmer
+ * @param {Contact} contact - The farmer contact the offer is from
  */
 
 Network.DEFAULTS = {
@@ -335,6 +342,25 @@ Network.prototype._signMessage = function(message, callback) {
 };
 
 /**
+ * Verifies that the supplied contact is valid and compatible
+ * @private
+ * @param {Contact} contact
+ */
+Network.prototype._validateContact = function(contact, callback) {
+  if (!utils.isCompatibleVersion(contact.protocol)) {
+    this._router.removeContact(contact);
+    return callback(new Error('Protocol version is incompatible'));
+  }
+
+  if (!utils.isValidContact(contact, process.env.STORJ_ALLOW_LOOPBACK)) {
+    this._router.removeContact(contact);
+    return callback(new Error('Invalid contact data supplied'));
+  }
+
+  callback(null);
+};
+
+/**
  * Verifies an incoming message
  * @private
  * @param {kad.Message} message
@@ -342,30 +368,33 @@ Network.prototype._signMessage = function(message, callback) {
  * @param {Function} callback
  */
 Network.prototype._verifyMessage = function(message, contact, callback) {
-  if (!utils.isCompatibleVersion(contact.protocol)) {
-    this._router.removeContact(contact);
-    return callback(new Error('Protocol version is incompatible'));
-  }
+  var self = this;
 
-  var messagekey = kad.Message.isRequest(message) ? 'params' : 'result';
-  var nonce = message[messagekey].nonce;
-  var signature = message[messagekey].signature;
+  this._validateContact(contact, function(err) {
+    if (err) {
+      return callback(err);
+    }
 
-  if (Date.now() > (constants.NONCE_EXPIRE + nonce)) {
-    return callback(new Error('Message signature expired'));
-  }
+    var messagekey = kad.Message.isRequest(message) ? 'params' : 'result';
+    var nonce = message[messagekey].nonce;
+    var signature = message[messagekey].signature;
 
-  var addr = bitcore.Address.fromPublicKeyHash(Buffer(contact.nodeID, 'hex'));
-  var signobj = this._createSignatureObject(signature);
+    if (Date.now() > (constants.NONCE_EXPIRE + nonce)) {
+      return callback(new Error('Message signature expired'));
+    }
 
-  this._verifySignature({
-    message: message,
-    nonce: nonce,
-    signobj: signobj,
-    address: addr,
-    contact: contact,
-    signature: signature
-  }, callback);
+    var addr = bitcore.Address.fromPublicKeyHash(Buffer(contact.nodeID, 'hex'));
+    var signobj = self._createSignatureObject(signature);
+
+    self._verifySignature({
+      message: message,
+      nonce: nonce,
+      signobj: signobj,
+      address: addr,
+      contact: contact,
+      signature: signature
+    }, callback);
+  });
 };
 
 /**
@@ -555,6 +584,10 @@ Network.prototype._findTunnel = function(neighbor, callback) {
       relayers: []
     }
   });
+
+  // NB: If we are going to be tunneled, we better not accept any tunnel
+  // NB: connections from other nodes, so let's override our maxTunnels.
+  this._transport._tunserver._options.maxTunnels = 0;
 
   if (!neighbor) {
     return callback(

--- a/lib/network/protocol.js
+++ b/lib/network/protocol.js
@@ -93,10 +93,6 @@ Protocol.prototype._handleOffer = function(params, callback) {
  * @private
  */
 Protocol.prototype._verifyContract = function(contract, contact, callback) {
-  if (!this._network._pendingContracts[contract.get('data_hash')]) {
-    return callback(new Error('Contract no longer open to offers'));
-  }
-
   if (!contract.verify('farmer', contact.nodeID)) {
     return callback(new Error('Invalid signature from farmer'));
   }
@@ -105,6 +101,11 @@ Protocol.prototype._verifyContract = function(contract, contact, callback) {
 
   if (!contract.isComplete()) {
     return callback(new Error('Contract is not complete'));
+  }
+
+  if (!this._network._pendingContracts[contract.get('data_hash')]) {
+    this._network.emit('unhandledOffer', contract, contact);
+    return callback(new Error('Contract no longer open to offers'));
   }
 
   callback(null);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "implementation of the storj protocol for node.js and the browser",
   "main": "index.js",
   "directories": {

--- a/test/bridgeclient.unit.js
+++ b/test/bridgeclient.unit.js
@@ -124,6 +124,29 @@ describe('BridgeClient', function() {
 
     });
 
+    describe('#destroyUser', function() {
+
+      it('should send the correct args to _request', function(done) {
+        var _request = sinon.stub(BridgeClient.prototype, '_request').callsArg(
+          3,
+          null,
+          {}
+        );
+        var client = new BridgeClient();
+        var data = { email: 'gordon@storj.io' };
+        client.destroyUser(data, function() {
+          _request.restore();
+          expect(_request.calledWithMatch(
+            'DELETE',
+            '/users/gordon@storj.io',
+            { redirect: undefined }
+          )).to.equal(true);
+          done();
+        });
+      });
+
+    });
+
   });
 
   describe('BridgeClient/Keys', function() {


### PR DESCRIPTION
* Fix issues with invalid contacts and bad protocol versions ending up in the routing table
* Do not try to tunnel if you are tunneled
* Emit a `unhandledOffer` event, when nodes receive an offer they are not expecting (needed for bridge)
* Add new `BridgeClient#destroyUser` method for upcoming bridge release
* Close #173 
* Close #172 
* Close #174 