### PR TITLE
Browser shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ jsdoc
 # Ignore browser build, but leave the directory
 dist/**
 !dist/.gitkeep
+
+# Jetbrains IDE
+.idea

--- a/index.js
+++ b/index.js
@@ -4,7 +4,28 @@
 
 'use strict';
 
+var NODE_EXECUTION_CONTEXT = typeof(process) !== 'undefined';
+
 require('./lib/patches')(); // NB: Apply any monkey patches
+
+if (NODE_EXECUTION_CONTEXT) {
+  //-- LOAD NODE COMPATIBLE MODULES
+
+  /** {@link EncryptStream} */
+  module.exports.EncryptStream = require('./lib/cryptostream/node/encrypt');
+
+  /** {@link DecryptStream} */
+  module.exports.DecryptStream = require('./lib/cryptostream/node/decrypt');
+
+} else {
+  //-- LOAD BROWSER COMPATIBLE MODULES
+
+  /** {@link EncryptStream} */
+  module.exports.EncryptStream = require('./lib/cryptostream/browser/encrypt');
+
+  /** {@link DecryptStream} */
+  module.exports.DecryptStream = require('./lib/cryptostream/browser/decrypt');
+}
 
 module.exports.version = require('./lib/version');
 
@@ -40,12 +61,6 @@ module.exports.TunnelDemuxer = require('./lib/tunnel/demultiplexer');
 
 /** {@link TunnelClient} */
 module.exports.TunnelClient = require('./lib/tunnel/client');
-
-/** {@link EncryptStream} */
-module.exports.EncryptStream = require('./lib/cryptostream/encrypt');
-
-/** {@link DecryptStream} */
-module.exports.DecryptStream = require('./lib/cryptostream/decrypt');
 
 /** {@link FileMuxer} */
 module.exports.FileMuxer = require('./lib/filemuxer');

--- a/lib/cryptostream/browser/crypto_stub.js
+++ b/lib/cryptostream/browser/crypto_stub.js
@@ -1,0 +1,11 @@
+var noop = function() {};
+var crypto = {
+  Cipheriv: {
+    prototype: noop
+  },
+  Decipheriv: {
+    prototype: noop
+  }
+};
+
+module.exports = crypto;

--- a/lib/cryptostream/browser/crypto_stub.js
+++ b/lib/cryptostream/browser/crypto_stub.js
@@ -1,10 +1,12 @@
 var noop = function() {};
 var crypto = {
   Cipheriv: {
-    prototype: noop
+    prototype: noop,
+    apply: noop
   },
   Decipheriv: {
-    prototype: noop
+    prototype: noop,
+    apply: noop
   }
 };
 

--- a/lib/cryptostream/browser/decrypt.js
+++ b/lib/cryptostream/browser/decrypt.js
@@ -1,0 +1,3 @@
+var crypto = require('./crypto_stub');
+var decrypt = require('../decrypt_factory')(crypto);
+module.exports = decrypt;

--- a/lib/cryptostream/browser/encrypt.js
+++ b/lib/cryptostream/browser/encrypt.js
@@ -1,0 +1,3 @@
+var crypto = require('./crypto_stub');
+var encrypt = require('../encrypt_factory')(crypto);
+module.exports = encrypt;

--- a/lib/cryptostream/decrypt_factory.js
+++ b/lib/cryptostream/decrypt_factory.js
@@ -1,9 +1,10 @@
 'use strict';
 
+module.exports = function(crypto) {
+
 var constants = require('../constants');
 var inherits = require('util').inherits;
 var assert = require('assert');
-var crypto = require('crypto');
 var DataCipherKeyIv = require('../cipherkeyiv');
 
 /**
@@ -40,5 +41,6 @@ function DecryptStream(keyiv) {
  */
 
 inherits(DecryptStream, crypto.Decipheriv);
-
-module.exports = DecryptStream;
+  
+return DecryptStream;
+};

--- a/lib/cryptostream/encrypt_factory.js
+++ b/lib/cryptostream/encrypt_factory.js
@@ -1,9 +1,10 @@
 'use strict';
 
+module.exports = function(crypto) {
+
 var constants = require('../constants');
 var inherits = require('util').inherits;
 var assert = require('assert');
-var crypto = require('crypto');
 var DataCipherKeyIv = require('../cipherkeyiv');
 
 /**
@@ -41,4 +42,5 @@ function EncryptStream(keyiv) {
 
 inherits(EncryptStream, crypto.Cipheriv);
 
-module.exports = EncryptStream;
+return EncryptStream;
+};

--- a/lib/cryptostream/node/decrypt.js
+++ b/lib/cryptostream/node/decrypt.js
@@ -1,0 +1,3 @@
+var crypto = require('crypto');
+var decrypt = require('../decrypt_factory')(crypto);
+module.exports = decrypt;

--- a/lib/cryptostream/node/encrypt.js
+++ b/lib/cryptostream/node/encrypt.js
@@ -1,0 +1,3 @@
+var crypto = require('crypto');
+var encrypt = require('../encrypt_factory')(crypto);
+module.exports = encrypt;

--- a/test/cryptostream.unit.js
+++ b/test/cryptostream.unit.js
@@ -19,7 +19,8 @@ describe('node EncryptStream', function() {
     });
 
     it('should create instance without the new keyword', function() {
-      expect(NodeEncryptStream(DataCipherKeyIv())).to.be.instanceOf(NodeEncryptStream);
+      expect(NodeEncryptStream(DataCipherKeyIv()))
+        .to.be.instanceOf(NodeEncryptStream);
     });
 
     it('should throw with an invalid keypair', function() {
@@ -43,7 +44,8 @@ describe('node DecryptStream', function() {
     });
 
     it('should create instance without the new keyword', function() {
-      expect(NodeDecryptStream(DataCipherKeyIv())).to.be.instanceOf(NodeDecryptStream);
+      expect(NodeDecryptStream(DataCipherKeyIv()))
+        .to.be.instanceOf(NodeDecryptStream);
     });
 
     it('should throw with an invalid keypair', function() {

--- a/test/cryptostream.unit.js
+++ b/test/cryptostream.unit.js
@@ -2,26 +2,29 @@
 
 var expect = require('chai').expect;
 var DataCipherKeyIv = require('../lib/cipherkeyiv');
-var EncryptStream = require('../lib/cryptostream/node/encrypt');
-var DecryptStream = require('../lib/cryptostream/node/decrypt');
+var NodeEncryptStream = require('../lib/cryptostream/node/encrypt');
+var NodeDecryptStream = require('../lib/cryptostream/node/decrypt');
+var BrowserEncryptStream = require('../lib/cryptostream/browser/encrypt');
+var BrowserDecryptStream = require('../lib/cryptostream/browser/decrypt');
+var cryptoStub = require('../lib/cryptostream/browser/crypto_stub');
 
-describe('EncryptStream', function() {
+describe('node EncryptStream', function() {
 
   describe('@constructor', function() {
 
     it('should create instance with the new keyword', function() {
-      expect(new EncryptStream(
+      expect(new NodeEncryptStream(
         DataCipherKeyIv()
-      )).to.be.instanceOf(EncryptStream);
+      )).to.be.instanceOf(NodeEncryptStream);
     });
 
     it('should create instance without the new keyword', function() {
-      expect(EncryptStream(DataCipherKeyIv())).to.be.instanceOf(EncryptStream);
+      expect(NodeEncryptStream(DataCipherKeyIv())).to.be.instanceOf(NodeEncryptStream);
     });
 
     it('should throw with an invalid keypair', function() {
       expect(function() {
-        EncryptStream(null);
+        NodeEncryptStream(null);
       }).to.throw(Error, 'Invalid cipher object supplied');
     });
 
@@ -29,23 +32,23 @@ describe('EncryptStream', function() {
 
 });
 
-describe('DecryptStream', function() {
+describe('node DecryptStream', function() {
 
   describe('@constructor', function() {
 
     it('should create instance with the new keyword', function() {
       expect(
-        new DecryptStream(DataCipherKeyIv())
-      ).to.be.instanceOf(DecryptStream);
+        new NodeDecryptStream(DataCipherKeyIv())
+      ).to.be.instanceOf(NodeDecryptStream);
     });
 
     it('should create instance without the new keyword', function() {
-      expect(DecryptStream(DataCipherKeyIv())).to.be.instanceOf(DecryptStream);
+      expect(NodeDecryptStream(DataCipherKeyIv())).to.be.instanceOf(NodeDecryptStream);
     });
 
     it('should throw with an invalid keypair', function() {
       expect(function() {
-        DecryptStream(null);
+        NodeDecryptStream(null);
       }).to.throw(Error, 'Invalid cipher object supplied');
     });
 
@@ -57,8 +60,8 @@ describe('CryptoStream/Integration', function() {
 
   it('should successfully encrypt and decrypt the data', function(done) {
     var keyiv = new DataCipherKeyIv();
-    var encrypter = new EncryptStream(keyiv);
-    var decrypter = new DecryptStream(keyiv);
+    var encrypter = new NodeEncryptStream(keyiv);
+    var decrypter = new NodeDecryptStream(keyiv);
     var input = ['HAY', 'GURL', 'HAY'];
     var output = '';
 
@@ -76,4 +79,42 @@ describe('CryptoStream/Integration', function() {
     encrypter.end();
   });
 
+});
+
+var shouldStubPrototype = function(member){
+  it('should expose a `prototype` property that is a function', function() {
+    expect(typeof(member.prototype)).to.equal('function');
+  });
+
+  it('should expose an `apply` property that is a function', function() {
+    expect(typeof(member.apply)).to.equal('function');
+  });
+};
+
+describe('crypto stub', function(){
+  describe('#Cipheriv', function(){
+    shouldStubPrototype(cryptoStub.Cipheriv);
+  });
+  
+  describe('#Decipheriv', function(){
+    shouldStubPrototype(cryptoStub.Decipheriv);
+  });
+});
+
+describe('browser EncryptStream', function(){
+  it('should not be undefined', function() {
+    var keyiv = new DataCipherKeyIv();
+    var encryptor = new BrowserEncryptStream(keyiv);
+
+    expect(typeof(encryptor)).to.not.equal('undefined');
+  });
+});
+
+describe('browser DecryptStream', function(){
+  it('should not be undefined', function() {
+    var keyiv = new DataCipherKeyIv();
+    var decryptor = new BrowserDecryptStream(keyiv);
+
+    expect(typeof(decryptor)).to.not.equal('undefined');
+  });
 });

--- a/test/cryptostream.unit.js
+++ b/test/cryptostream.unit.js
@@ -2,8 +2,8 @@
 
 var expect = require('chai').expect;
 var DataCipherKeyIv = require('../lib/cipherkeyiv');
-var EncryptStream = require('../lib/cryptostream/encrypt');
-var DecryptStream = require('../lib/cryptostream/decrypt');
+var EncryptStream = require('../lib/cryptostream/node/encrypt');
+var DecryptStream = require('../lib/cryptostream/node/decrypt');
 
 describe('EncryptStream', function() {
 


### PR DESCRIPTION
## The problem

As far as we can tell, nobody (i.e. neither webpack nor browserify) has a complete 
API-compatible polyfill for the node `crypto` module which includes generic classes for 
`Cipheriv` and `Decipheriv`. 

Webpack only stubs the methods which would create instances of these classes 
(`crypto.createCipheriv` and `crypto.createDecipheriv`) and browserify works 
around the lack of the generic class by delegating directly to the browserify 
AES and DES modules.

This leads to a problem when trying to use the storj core in the browser.

As far as we're aware this issue only extends to this libs dependency in the bridge-gui 
repo where, as far we know, doesn't currently require actual crypto implementation. 

## Proposed solution

This PR looks at the idea of adding a thin layer of conditional logic to load 
a node or browser compatible version of the lib based on what we believe the 
execution context to be.

Currently, to determine the execution context, the node global variable, 
`process`, is being used. If it is present we assume we're in a node context 
and a browser otherwise. 

This is sub-par but sufficient until [the `browser` 
npm package.json property proposal](https://github.com/defunctzombie/package-browser-field-spec) makes it into the spec.