### PR TITLE
Cryptostream support for browserify/webpack

### DIFF
--- a/lib/cryptostream/decrypt.js
+++ b/lib/cryptostream/decrypt.js
@@ -4,6 +4,7 @@ var constants = require('../constants');
 var inherits = require('util').inherits;
 var assert = require('assert');
 var crypto = require('crypto');
+var stream = require('readable-stream');
 var DataCipherKeyIv = require('../cipherkeyiv');
 
 /**
@@ -21,12 +22,32 @@ function DecryptStream(keyiv) {
 
   assert(keyiv instanceof DataCipherKeyIv, 'Invalid cipher object supplied');
 
-  this.keyiv = keyiv;
+  this._decipher = crypto.createDecipheriv.apply(
+    this,
+    [constants.CIPHER_ALG].concat(keyiv.getCipherKeyIv())
+  );
 
-  crypto.Decipheriv.apply(this, [constants.CIPHER_ALG].concat(
-    keyiv.getCipherKeyIv()
-  ));
+  stream.Transform.call(this);
 }
+
+inherits(DecryptStream, stream.Transform);
+
+/**
+ * Writes to the underlying decipher
+ * @private
+ */
+DecryptStream.prototype._transform = function(chunk, enc, callback) {
+  this._decipher.write(chunk);
+  callback(null, this._decipher.read());
+};
+
+/**
+ * Ensures there is no more data to be read from decipher
+ * @private
+ */
+DecryptStream.prototype._flush = function(callback) {
+  callback(null, this._decipher.read());
+};
 
 /**
  * Triggered when some input bytes have become decrypted output bytes
@@ -38,7 +59,5 @@ function DecryptStream(keyiv) {
  * Triggered when the stream has ended
  * @event DecryptStream#end
  */
-
-inherits(DecryptStream, crypto.Decipheriv);
 
 module.exports = DecryptStream;

--- a/lib/cryptostream/encrypt.js
+++ b/lib/cryptostream/encrypt.js
@@ -1,9 +1,10 @@
 'use strict';
 
 var constants = require('../constants');
-var inherits = require('util').inherits;
 var assert = require('assert');
 var crypto = require('crypto');
+var stream = require('readable-stream');
+var inherits = require('util').inherits;
 var DataCipherKeyIv = require('../cipherkeyiv');
 
 /**
@@ -21,12 +22,32 @@ function EncryptStream(keyiv) {
 
   assert(keyiv instanceof DataCipherKeyIv, 'Invalid cipher object supplied');
 
-  this.keyiv = keyiv;
+  this._cipher = crypto.createCipheriv.apply(
+    this,
+    [constants.CIPHER_ALG].concat(keyiv.getCipherKeyIv())
+  );
 
-  crypto.Cipheriv.apply(this, [constants.CIPHER_ALG].concat(
-    keyiv.getCipherKeyIv()
-  ));
+  stream.Transform.call(this);
 }
+
+inherits(EncryptStream, stream.Transform);
+
+/**
+ * Writes to the internal cipheriv
+ * @private
+ */
+EncryptStream.prototype._transform = function(chunk, enc, callback) {
+  this._cipher.write(chunk);
+  callback(null, this._cipher.read());
+};
+
+/**
+ * Ensures that there is no remaining bytes to be read from cipher
+ * @private
+ */
+EncryptStream.prototype._flush = function(callback) {
+  callback(null, this._cipher.read());
+};
 
 /**
  * Triggered when some input bytes have become encrypted output bytes
@@ -38,7 +59,5 @@ function EncryptStream(keyiv) {
  * Triggered when the stream has ended
  * @event EncryptStream#end
  */
-
-inherits(EncryptStream, crypto.Cipheriv);
 
 module.exports = EncryptStream;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "implementation of the storj protocol for node.js and the browser",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Related: #176

---

This PR changes the `DecryptStream` and `EncryptStream` classes to work with the existing shims provided by Browserify and Webpack by converting them into `stream.Transform`s with internal `_cipher`/`_decipher` members created with `crypto.createCipheriv` and `crypto.createDecipheriv` instead of inheriting from the undocumented `Cipheriv` and `Decipheriv` classes that are not shimmed.