### PR TITLE
v1.4.0 + Protocol 0.7.1 (Redundancy and Replication)

### DIFF
--- a/bin/storj.js
+++ b/bin/storj.js
@@ -33,7 +33,7 @@ program.option('-k, --keypass <password>', 'unlock keyring without prompt');
 function log(type, message, args) {
   switch (type) {
     case 'debug':
-      message = colors.bold.magena(' [debug]  ') + message;
+      message = colors.bold.magenta(' [debug]  ') + message;
       break;
     case 'info':
       message = colors.bold.cyan(' [info]   ') + message;
@@ -46,6 +46,7 @@ function log(type, message, args) {
       break;
   }
 
+  message = colors.bold.gray(' [' + new Date() + ']') + message;
   console.log.apply(console, [message].concat(args || []));
 }
 

--- a/bin/storj.js
+++ b/bin/storj.js
@@ -82,7 +82,7 @@ function makeTempDir(callback) {
 function loadKeyPair() {
   if (!fs.existsSync(KEYPATH)) {
     log('error', 'You have not authenticated, please login.');
-    process.exit();
+    process.exit(1);
   }
 
   return storj.KeyPair(fs.readFileSync(KEYPATH).toString());

--- a/doc/protocol-spec.md
+++ b/doc/protocol-spec.md
@@ -778,7 +778,7 @@ to store the data and that the number of items in the `audit_tree` is equal to
 the next power of 2 of the `audit_count` supplied in the original contract.
 
 Once verified, the farmer must respond with a generated token that the renter
-of another authorized party can use to open a data channel with the farmer
+or another authorized party can use to open a data channel with the farmer
 (via websocket) to deliver the data as a binary stream.
 
 > For more information on the Data Channel specification see the tutorial for

--- a/doc/protocol-spec.md
+++ b/doc/protocol-spec.md
@@ -827,9 +827,11 @@ In these scenarios, renters can offload the burden of storing multiple copies
 of a shard to the farmers by issuing a `MIRROR` RPC in lieu of establishing
 a data channel. A `MIRROR` RPC instructs a contracted farmer to retrieve the
 data already uploaded to another farmer by providing them with a retrieval
-token authorized by another farmer. This allows the renter to incur the
-bandwidth and latency once and instead pay the recently contracted farmer to
-transfer the data to another farmer for redundancy.
+token authorized by another farmer (this is performed by issuing a `RETRIEVE`
+RPC message - see *Downloading Consigned Data* later in this document). This
+allows the renter to incur the bandwidth and latency once and instead pay the
+recently contracted farmer to transfer the data to another farmer for
+redundancy.
 
 To initiate this process, instead of opening a data channel, issue a `MIRROR`
 RPC message to the farmer after contract negotiation is complete:
@@ -866,7 +868,7 @@ Once the mirroring farmer receives the request, it should open a data channel
 to the original farmer and pass along the supplied token and data hash in the
 initial authorization frame. Once the mirroring farmer begins receiving data
 it must respond to the renter's request with a simple acknowledgement to
-indicate that the mirror operation has succeeded.
+indicate that the mirror operation was successfully initiated.
 
 ```
 {

--- a/doc/protocol-spec.md
+++ b/doc/protocol-spec.md
@@ -731,7 +731,11 @@ offer loop or until both parties have signed the same contract.
 Once a storage contract has been signed by both parties, the renter may execute
 the terms of the contract by issuing a `CONSIGN` message to the farmer. The
 purpose of this message is to deliver the data referenced by the contract for
-the farmer to store. The consign message must contain the hex-encoded
+the farmer to store.
+
+#### CONSIGN
+
+The consign message must contain the hex-encoded
 `data_shard` itself, the `contract_hash`, as well as an `audit_tree` that
 contains the bottom leaves of the audit strategy's merkle tree (see **Auditing
 a Storage Contract** below).
@@ -823,6 +827,8 @@ shards. Additionally, the amount of bandwidth consumed by the renter increases
 in the same way as the renter will have to upload the data for each redundant
 shard.
 
+#### MIRROR
+
 In these scenarios, renters can offload the burden of storing multiple copies
 of a shard to the farmers by issuing a `MIRROR` RPC in lieu of establishing
 a data channel. A `MIRROR` RPC instructs a contracted farmer to retrieve the
@@ -908,6 +914,8 @@ as hex. In order to ensure that the resulting merkle tree is properly
 the audit count. To ensure this, the additional leaves can simply be the double
 `RIPEMD160(SHA256(''))` (the same hash function for an audit, but applied to an
 empty buffer).
+
+#### AUDIT
 
 To audit a farmer is to request proof that it is still honoring the terms of
 the storage contract without the need to have them supply the entire
@@ -1012,7 +1020,7 @@ Conversely, if the verification succeeds and the renter does not issue the
 payment in a timely manner, then the contract is also null and the farmer may
 decide to cease storage of the data.
 
-### Downloading Consigned Data
+#### RETRIEVE
 
 When a renter wishes to retrieve data that is stored under contract, it can
 issue a `RETRIEVE` RPC message that includes the `data_hash` to the farmer

--- a/doc/renting-data.md
+++ b/doc/renting-data.md
@@ -195,6 +195,57 @@ implementing clients. If you do not wish to manage this yourself, consider
 running a [Bridge](https://github.com/storj/bridge) or using the
 [Storj API](https://storj.io).
 
+### Replicating Shards for Redundancy
+
+Once we have successfully consigned our data to a farmer, we can ensure that in
+the event that farmer disappears, our data can be recovered from elsewhere. We
+use mirrors to accomplish this. Mirroring is a method for *passively*
+replicating our data, meaning that instead of uploading it again, we instruct a
+new farmer to retrieve it from the location we already stored it.
+
+To do this we are going to need:
+
+* {@link DataChannelPointer} - for representing the location of the shard
+
+> We are also going to use the [async](https://github.com/caolan/async) module
+> for managing flow control.
+
+First we'll need to negotiate a few more contracts, then authorize some
+retrieval tokens (outlined later in this document), and finally request some
+mirrors.
+
+```
+var redundancy = 3;
+var mirrors = [];
+
+function _getMirroringContract(n, next) {
+  renter.getStorageOffer(contract, function(mirror, contract) {
+    renter.getRetrieveToken(farmer, contract, function(err, token) {
+      if (err) {
+        return next(err);
+      }
+
+      mirrors.push(mirror);
+      next(null, new storj.DataChannelPointer(farmer, hash, token));
+    });
+  });
+}
+
+async.timesSeries(redundancy, _getMirroringContract, function(err, sources) {
+  if (err) {
+    return console.error(err);
+  }
+
+  renter.createMirrors(sources, mirrors, function(err, completed) {
+    if (err) {
+      return console.error('Failed to replicate to all mirrors');
+    }
+
+    console.info('Replicated to %s mirrors', completed.length);
+  });
+});
+```
+
 ### Auditing Farmer Storage
 
 Now that we have successfully consigned a shard, we will want to be sure that

--- a/doc/renting-data.md
+++ b/doc/renting-data.md
@@ -236,7 +236,7 @@ async.timesSeries(redundancy, _getMirroringContract, function(err, sources) {
     return console.error(err);
   }
 
-  renter.createMirrors(sources, mirrors, function(err, completed) {
+  renter.getMirrorNodes(sources, mirrors, function(err, completed) {
     if (err) {
       return console.error('Failed to replicate to all mirrors');
     }

--- a/index.js
+++ b/index.js
@@ -26,6 +26,9 @@ module.exports.DataChannelClient = require('./lib/datachannel/client');
 /** {@link DataChannelServer} */
 module.exports.DataChannelServer = require('./lib/datachannel/server');
 
+/** {@link DataChannelPointer} */
+module.exports.DataChannelPointer = require('./lib/datachannel/pointer');
+
 /** {@link Protocol} */
 module.exports.Protocol = require('./lib/network/protocol');
 

--- a/index.js
+++ b/index.js
@@ -118,3 +118,6 @@ module.exports.constants = require('./lib/constants');
 
 /** {@link utils} */
 module.exports.utils = require('./lib/utils');
+
+/** {@link deps} */
+module.exports.deps = require('./lib/deps');

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -13,6 +13,8 @@ module.exports = {
   NONCE_EXPIRE: 30000,
   /** @constant {Number} RPC_TIMEOUT - Max wait time for a RPC response */
   RPC_TIMEOUT: 30000,
+  /** @constant {Number} NET_REENTRY - Max wait time before re-entering net */
+  NET_REENTRY: 600000,
   /** @constant {Number} AUDIT_BYTES - Number of bytes for audit challenge */
   AUDIT_BYTES: 32,
   /** @constant {Number} CLEAN_INTERVAL - Interval for reaping stale shards */

--- a/lib/datachannel/client.js
+++ b/lib/datachannel/client.js
@@ -186,6 +186,8 @@ DataChannelClient.getStreamFromPointer = function(pointer, callback) {
       callback(null, dcx.createReadStream(pointer.token, pointer.hash));
     }
   });
+
+  return dcx;
 };
 /**
  * This callback is called when the client is open and stream is created

--- a/lib/datachannel/client.js
+++ b/lib/datachannel/client.js
@@ -6,6 +6,7 @@ var assert = require('assert');
 var events = require('events');
 var inherits = require('util').inherits;
 var url = require('url');
+var DataChannelPointer = require('./pointer');
 
 /**
  * Creates a data channel client for sending and receiving consigned file shards
@@ -164,5 +165,33 @@ DataChannelClient.getChannelURL = function(contact) {
     port: contact.port
   });
 };
+
+/**
+ * Creates a Readable or Writable stream from a {@link DataChannelPointer}
+ * @static
+ * @param {DataChannelPointer} pointer - The pointer to create stream
+ * @param {DataChannelClient~getStreamFromPointerCallback} callback
+ */
+DataChannelClient.getStreamFromPointer = function(pointer, callback) {
+  assert(pointer instanceof DataChannelPointer, 'Invalid pointer supplied');
+
+  var dcx = new DataChannelClient(pointer.farmer);
+
+  dcx.on('error', callback).on('open', function() {
+    dcx.removeAllListeners('error');
+
+    if (pointer.operation === 'PUSH') {
+      callback(null, dcx.createWriteStream(pointer.token, pointer.hash));
+    } else {
+      callback(null, dcx.createReadStream(pointer.token, pointer.hash));
+    }
+  });
+};
+/**
+ * This callback is called when the client is open and stream is created
+ * @callback DataChannelClient~getStreamFromPointerCallback
+ * @param {Error|null} err - If opening client failed, an error object
+ * @param {stream.Writable|stream.Readable} stream - The data channel stream
+ */
 
 module.exports = DataChannelClient;

--- a/lib/datachannel/pointer.js
+++ b/lib/datachannel/pointer.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var assert = require('assert');
+var Contact = require('../network/contact');
+
+/**
+ * Represents a pointer for opening a {@link DataChannelClient} stream
+ * @constructor
+ * @param {Contact} contact - The farmer the pointer is for
+ * @param {String} hash - The hash of the data to consign or retrieve
+ * @param {String} token - The authorization token fot the operation
+ * @param {String} [operation=PULL] - The type of operation (PUSH or PULL)
+ */
+function DataChannelPointer(contact, hash, token, operation) {
+  if (!(this instanceof DataChannelPointer)) {
+    return new DataChannelPointer(contact, hash, token, operation);
+  }
+
+  assert(contact instanceof Contact, 'Invalid contact supplied');
+  assert(typeof hash === 'string', 'Invalid hash supplied');
+  assert(hash.length === 40, 'Invalid hash supplied');
+  assert(typeof token === 'string', 'Invalid token supplied');
+  assert(token.length === 40, 'Invalid token supplied');
+
+  this.farmer = contact;
+  this.hash = hash;
+  this.token = token;
+  this.operation = operation || 'PULL';
+}
+
+module.exports = DataChannelPointer;

--- a/lib/deps.js
+++ b/lib/deps.js
@@ -1,0 +1,16 @@
+/**
+ * @module storj/deps
+ */
+
+'use strict';
+
+module.exports = (function() {
+  var pack = require('../package');
+  var deps = {};
+
+  for (var _dep in pack.dependencies) {
+    deps[_dep] = require(_dep);
+  }
+
+  return deps;
+})();

--- a/lib/interfaces/farmer.js
+++ b/lib/interfaces/farmer.js
@@ -202,8 +202,12 @@ FarmerInterface.prototype._shouldSendOffer = function(contract) {
   var pendingOffersLength = this._pendingOffers.length;
   var conOffer = (pendingOffersLength < this._options.concurrency);
 
-  this._logger.debug('pending offers %s is less than concurrency %s: %s',
-    pendingOffersLength, conOffer, this._options.concurrency);
+  this._logger.debug(
+    'pending offers %s is less than concurrency %s: %s',
+    pendingOffersLength,
+    conOffer,
+    this._options.concurrency
+  );
   this._logger.debug('negotiator returned: %s', this._negotiator(contract));
   this._logger.debug('we have enough free space: %s', this._hasFreeSpace);
 

--- a/lib/interfaces/renter.js
+++ b/lib/interfaces/renter.js
@@ -107,14 +107,14 @@ RenterInterface.prototype.getStorageProof = function(farmer, item, callback) {
  */
 
 /**
- * Requests a consignment token from the given farmer for opening a
+ * Requests a consignment pointer from the given farmer for opening a
  * {@link DataChannelClient} for transferring the the data shard to the farmer
  * @param {Contact} farmer - The farmer contact object for requesting token
  * @param {Contract} contract - The storage contract for this consignment
  * @param {AuditStream} audit - The audit object for merkle leaves
- * @param {RenterInterface~getConsignTokenCallback} callback - Token handler
+ * @param {RenterInterface~getConsignmentPointerCallback} callback
  */
-RenterInterface.prototype.getConsignToken = function(f, c, a, callback) {
+RenterInterface.prototype.getConsignmentPointer = function(f, c, a, callback) {
   var farmer = f;
   var contract = c;
   var audit = a;
@@ -141,7 +141,38 @@ RenterInterface.prototype.getConsignToken = function(f, c, a, callback) {
       return callback(new Error(response.error.message));
     }
 
-    callback(null, response.result.token);
+    callback(null, DataChannelPointer(
+      f,
+      contract.get('data_hash'),
+      response.result.token,
+      'PUSH'
+    ));
+  });
+};
+/**
+ * This callback is called upon receipt of a consignment token from
+ * {@link RenterInterface#getConsignmentPointer}
+ * @callback RenterInterface~getConsignmentPointerCallback
+ * @param {Error|null} err - If requesting the token failed, an error object
+ * @param {DataChannelPointer} pointer - Pointer for a {@link DataChannelClient}
+ */
+
+/**
+ * Requests a consignment token from the given farmer for opening a
+ * {@link DataChannelClient} for transferring the the data shard to the farmer
+ * @deprecated since version 1.4.0
+ * @param {Contact} farmer - The farmer contact object for requesting token
+ * @param {Contract} contract - The storage contract for this consignment
+ * @param {AuditStream} audit - The audit object for merkle leaves
+ * @param {RenterInterface~getConsignTokenCallback} callback
+ */
+RenterInterface.prototype.getConsignToken = function(f, c, a, callback) {
+  this.getConsignmentPointer(f, c, a, function(err, pointer) {
+    if (err) {
+      return callback(err);
+    }
+
+    callback(null, pointer.token);
   });
 };
 /**
@@ -157,9 +188,9 @@ RenterInterface.prototype.getConsignToken = function(f, c, a, callback) {
  * {@link DataChannelClient} for transferring the data shard from the farmer
  * @param {Contact} farmer - The farmer contact object for requesting token
  * @param {Contract} contract - The storage contract for this consignment
- * @param {RenterInterface~getRetrieveTokenCallback} callback - Token handler
+ * @param {RenterInterface~getRetrievalPointerCallback} callback - Token handler
  */
-RenterInterface.prototype.getRetrieveToken = function(f, c, callback) {
+RenterInterface.prototype.getRetrievalPointer = function(f, c, callback) {
   var farmer = f;
   var contract = c;
 
@@ -183,16 +214,46 @@ RenterInterface.prototype.getRetrieveToken = function(f, c, callback) {
       return callback(new Error(response.error.message));
     }
 
-    callback(null, response.result.token);
+    callback(null, DataChannelPointer(
+      f,
+      contract.get('data_hash'),
+      response.result.token,
+      'PULL'
+    ));
   });
 };
 /**
  * This callback is called upon receipt of a retrieval token from
  * {@link RenterInterface#getRetrieveToken}
- * @callback RenterInterface~getRetrieveTokenCallback
+ * @callback RenterInterface~getRetrievalPointerCallback
  * @param {Error|null} err - If requesting the token failed, an error object
- * @param {String} token - Consignment token for a {@link DataChannelClient}
+ * @param {DataChannelPointer} pointer - Pointer for a {@link DataChannelClient}
  */
+
+/**
+* Requests a retrieval token from the given farmer for opening a
+* {@link DataChannelClient} for transferring the the data shard from the farmer
+* @deprecated since version 1.4.0
+* @param {Contact} farmer - The farmer contact object for requesting token
+* @param {Contract} contract - The storage contract for this retrieval
+* @param {RenterInterface~getConsignTokenCallback} callback
+*/
+RenterInterface.prototype.getRetrieveToken = function(f, c, callback) {
+  this.getRetrievalPointer(f, c, function(err, pointer) {
+    if (err) {
+      return callback(err);
+    }
+
+    callback(null, pointer.token);
+  });
+};
+/**
+* This callback is called upon receipt of a consignment token from
+* {@link RenterInterface#getConsignToken}
+* @callback RenterInterface~getConsignTokenCallback
+* @param {Error|null} err - If requesting the token failed, an error object
+* @param {String} token - Consignment token for a {@link DataChannelClient}
+*/
 
 /**
  * Requests that the given destination farmers mirror the data from the source

--- a/lib/interfaces/renter.js
+++ b/lib/interfaces/renter.js
@@ -199,9 +199,9 @@ RenterInterface.prototype.getRetrieveToken = function(f, c, callback) {
  * {@link DataChannelPointer}.
  * @param {Array.<DataChannelPointer>} sources - Pointers for each destination
  * @param {Array.<Contact>} destinations - The farmers to replicate to
- * @param {RenterInterface~createMirrorsCallback} callback - Results handler
+ * @param {RenterInterface~getMirrorNodesCallback} callback - Results handler
  */
-RenterInterface.prototype.createMirrors = function(sources, dests, callback) {
+RenterInterface.prototype.getMirrorNodes = function(sources, dests, callback) {
   var self = this;
 
   assert(Array.isArray(sources), 'Invalid sources list supplied');
@@ -248,7 +248,7 @@ RenterInterface.prototype.createMirrors = function(sources, dests, callback) {
 };
 /**
  * This callback is called upon acknowledgement of a mirror request
- * @callback RenterInterface~createMirrorsCallback
+ * @callback RenterInterface~getMirrorNodesCallback
  * @param {Error|null} err - If requesting all mirrors failed, an error object
  * @param {Array.<Contact>} results - The farmers who successfully mirrored
  */

--- a/lib/interfaces/renter.js
+++ b/lib/interfaces/renter.js
@@ -267,6 +267,10 @@ RenterInterface.prototype.getMirrorNodes = function(sources, dests, callback) {
 
   assert(Array.isArray(sources), 'Invalid sources list supplied');
   assert(Array.isArray(dests), 'Invalid destination list supplied');
+  assert(
+    sources.length === dests.length,
+    'Sources and destinations must have equal length'
+  );
 
   sources.forEach(function(src) {
     assert(src instanceof DataChannelPointer, 'Invalid pointer supplied');
@@ -288,7 +292,7 @@ RenterInterface.prototype.getMirrorNodes = function(sources, dests, callback) {
       }
      });
 
-    self._transport.send(source.farmer, message, function(err, response) {
+    self._transport.send(destination, message, function(err, response) {
       if (err || response.error) {
         return next(false);
       }

--- a/lib/interfaces/renter.js
+++ b/lib/interfaces/renter.js
@@ -276,7 +276,7 @@ RenterInterface.prototype.getMirrorNodes = function(sources, dests, callback) {
     assert(dest instanceof Contact, 'Invalid destination supplied');
   });
 
-  function _sendMirrorRequest(destination, callback) {
+  function _sendMirrorRequest(destination, next) {
     var source = sources.shift();
     var message = new kad.Message({
       method: 'MIRROR',
@@ -288,12 +288,12 @@ RenterInterface.prototype.getMirrorNodes = function(sources, dests, callback) {
       }
      });
 
-    self._transport.send(source, message, function(err, response) {
+    self._transport.send(source.farmer, message, function(err, response) {
       if (err || response.error) {
-        return callback(false);
+        return next(false);
       }
 
-      callback(true);
+      next(true);
     });
   }
 

--- a/lib/interfaces/renter.js
+++ b/lib/interfaces/renter.js
@@ -8,6 +8,8 @@ var kad = require('kad');
 var Network = require('../network');
 var inherits = require('util').inherits;
 var StorageItem = require('../storage/item');
+var async = require('async');
+var DataChannelPointer = require('../datachannel/pointer');
 
 /**
  * Creates and a new farmer interface
@@ -190,6 +192,65 @@ RenterInterface.prototype.getRetrieveToken = function(f, c, callback) {
  * @callback RenterInterface~getRetrieveTokenCallback
  * @param {Error|null} err - If requesting the token failed, an error object
  * @param {String} token - Consignment token for a {@link DataChannelClient}
+ */
+
+/**
+ * Requests that the given destination farmers mirror the data from the source
+ * {@link DataChannelPointer}.
+ * @param {Array.<DataChannelPointer>} sources - Pointers for each destination
+ * @param {Array.<Contact>} destinations - The farmers to replicate to
+ * @param {RenterInterface~createMirrorsCallback} callback - Results handler
+ */
+RenterInterface.prototype.createMirrors = function(sources, dests, callback) {
+  var self = this;
+
+  assert(Array.isArray(sources), 'Invalid sources list supplied');
+  assert(Array.isArray(dests), 'Invalid destination list supplied');
+
+  sources.forEach(function(src) {
+    assert(src instanceof DataChannelPointer, 'Invalid pointer supplied');
+  });
+
+  dests.forEach(function(dest) {
+    assert(dest instanceof Contact, 'Invalid destination supplied');
+  });
+
+  function _sendMirrorRequest(destination, callback) {
+    var source = sources.shift();
+    var message = new kad.Message({
+      method: 'MIRROR',
+      params: {
+        data_hash: source.hash,
+        token: source.token,
+        farmer: source.farmer,
+        contact: self._contact
+      }
+     });
+
+    self._transport.send(source, message, function(err, response) {
+      if (err || response.error) {
+        return callback(false);
+      }
+
+      callback(true);
+    });
+  }
+
+  function _onMirrorRequestsComplete(results) {
+    if (results.length === 0) {
+      return callback(new Error('All mirror requests failed'));
+    }
+
+    callback(null, results);
+  }
+
+  async.filter(dests, _sendMirrorRequest, _onMirrorRequestsComplete);
+};
+/**
+ * This callback is called upon acknowledgement of a mirror request
+ * @callback RenterInterface~createMirrorsCallback
+ * @param {Error|null} err - If requesting all mirrors failed, an error object
+ * @param {Array.<Contact>} results - The farmers who successfully mirrored
  */
 
 module.exports = RenterInterface;

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -132,6 +132,7 @@ Network.prototype.join = function(callback) {
   this._transport.before('receive', kad.hooks.protocol(
     this._protocol.handlers()
   ));
+  this._transport.after('receive', this._updateActivityCounter.bind(this));
 
   this._node = new kad.Node({
     transport: this._transport,
@@ -764,6 +765,19 @@ Network.prototype._startRouterCleaner = function() {
     var dropped = self._cleanRoutingTable();
     self._logger.debug('dropping %s bad contacts from router', dropped.length);
   }, constants.ROUTER_CLEAN_INTERVAL);
+};
+
+/**
+ * Resets the countdown until network re-entry due to inactivity
+ * @private
+ */
+Network.prototype._updateActivityCounter = function() {
+  clearTimeout(this._reentranceCountdown);
+
+  this._reentranceCountdown = setTimeout(
+    this._enterOverlay.bind(this, utils.noop),
+    constants.NET_REENTRY
+  );
 };
 
 module.exports = Network;

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -689,10 +689,11 @@ Network.prototype._establishTunnel = function(tunnels, callback) {
 
     tunclient.on('open', function() {
       self._logger.info('tunnel successfully established: %j', alias);
+
       self._contact.address = alias.address;
       self._contact.port = alias.port;
 
-      self._logger.info('testing newly established tunnel', alias);
+      self._logger.info('testing newly established tunnel: %j', alias);
       checker.check(self._contact, function(err) {
         if (err) {
           self._logger.warn('tunnel test failed, establishing new tunnel');
@@ -706,6 +707,7 @@ Network.prototype._establishTunnel = function(tunnels, callback) {
 
     tunclient.on('close', function onTunnelClosed() {
       self._logger.warn('tunnel connection closed');
+      tunclient.removeAllListeners('error');
       self._establishTunnel(tunnels, callback);
     });
 
@@ -714,6 +716,7 @@ Network.prototype._establishTunnel = function(tunnels, callback) {
         'tunnel connection lost, reason: %s',
         err.message
       );
+      tunclient.removeAllListeners();
       self._establishTunnel(tunnels, callback);
     });
 

--- a/lib/network/protocol.js
+++ b/lib/network/protocol.js
@@ -10,6 +10,7 @@ var kad = require('kad');
 var async = require('async');
 var Contact =  require('./contact');
 var constants = require('../constants');
+var DataChannelClient = require('../datachannel/client');
 
 /**
  * Defines the Storj protocol methods and mounts on a {@link Network} instance
@@ -235,7 +236,40 @@ Protocol.prototype._handleConsign = function(params, callback) {
  * @param {Function} callback
  */
 Protocol.prototype._handleMirror = function(params, callback) {
-  callback(new Error('Method not implemented'));
+  var self = this;
+  var hash = params.data_hash;
+  var token = params.token;
+
+  self._network._manager.load(hash, function(err, item) {
+    if (err) {
+      return callback(err);
+    }
+
+    // NB: Don't mirror data we are not contracted for
+    if (!item.contracts[params.contact.nodeID]) {
+      return callback(new Error('No contract found for shard'));
+    }
+
+    // NB: Don't mirror is we already have the shard
+    if (typeof item.shard.write !== 'function') {
+      return callback(null, {});
+    }
+
+    self._logger.info(
+      'opening datachannel with %j to mirror %s',
+      params.farmer,
+      hash
+    );
+
+    var dcx = new DataChannelClient(params.farmer);
+
+    dcx.on('error', callback).on('open', function() {
+      self._logger.info('datachannel successfully established for mirror');
+      dcx.removeAllListeners('error');
+      dcx.createReadStream(token, hash).pipe(item.shard);
+      callback(null, {});
+    });
+  });
 };
 
 /**
@@ -249,14 +283,14 @@ Protocol.prototype._handleRetrieve = function(params, callback) {
   var hash = params.data_hash;
   var token = utils.generateToken();
 
-  // TODO: We will need to increment the download count to track payments, as
-  // TODO: well as make sure that the requester is allowed to fetch the shard
-  // TODO: as part of the contract.
-
   self._network._manager.load(hash, function(err, item) {
     if (err) {
       return callback(err);
     }
+
+    // TODO: We will need to increment the download count to track payments, as
+    // TODO: well as make sure that the requester is allowed to fetch the shard
+    // TODO: as part of the contract.
 
     self._logger.info(
       'authorizing data channel for %s', params.contact.nodeID

--- a/lib/network/protocol.js
+++ b/lib/network/protocol.js
@@ -229,6 +229,16 @@ Protocol.prototype._handleConsign = function(params, callback) {
 };
 
 /**
+ * Handles MIRROR messages
+ * @private
+ * @param {Object} params
+ * @param {Function} callback
+ */
+Protocol.prototype._handleMirror = function(params, callback) {
+  callback(new Error('Method not implemented'));
+};
+
+/**
  * Handles RETRIEVE messages
  * @private
  * @param {Object} params
@@ -415,6 +425,7 @@ Protocol.prototype.handlers = function() {
     OFFER: this._handleOffer.bind(this),
     AUDIT: this._handleAudit.bind(this),
     CONSIGN: this._handleConsign.bind(this),
+    MIRROR: this._handleMirror.bind(this),
     RETRIEVE: this._handleRetrieve.bind(this),
     PROBE: this._handleProbe.bind(this),
     FIND_TUNNEL: this._handleFindTunnel.bind(this),

--- a/lib/network/protocol.js
+++ b/lib/network/protocol.js
@@ -250,7 +250,7 @@ Protocol.prototype._handleMirror = function(params, callback) {
       return callback(new Error('No contract found for shard'));
     }
 
-    // NB: Don't mirror is we already have the shard
+    // NB: Don't mirror if we already have the shard
     if (typeof item.shard.write !== 'function') {
       return callback(null, {});
     }

--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -59,11 +59,13 @@ Transport.prototype._open = function(callback) {
 
   if (ip.isPublic(self._contact.address) || self._noforward) {
     self._isPublic = true;
+
     if (ip.isPrivate(self._contact.address)) {
       self._log.error(
-        'you are not bound to a public address, traversal strategies disabled.'
+        'you are not bound to a public address, traversal strategies disabled'
       );
     }
+
     return kad.transports.HTTP.prototype._open.call(self, callback);
   }
 

--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -60,6 +60,7 @@ Transport.prototype._open = function(callback) {
   if (ip.isPublic(self._contact.address) || self._noforward) {
     self._isPublic = true;
 
+    /* istanbul ignore else */
     if (ip.isPrivate(self._contact.address)) {
       self._log.error(
         'you are not bound to a public address, traversal strategies disabled'

--- a/lib/version.js
+++ b/lib/version.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 var postfix = process.env.STORJ_NETWORK ? '-' + process.env.STORJ_NETWORK : '';
 
 module.exports = {
-  protocol: '0.8.0' + postfix,
+  protocol: '0.7.1' + postfix,
   software: require('../package').version
 };
 

--- a/lib/version.js
+++ b/lib/version.js
@@ -5,7 +5,7 @@ var assert = require('assert');
 var postfix = process.env.STORJ_NETWORK ? '-' + process.env.STORJ_NETWORK : '';
 
 module.exports = {
-  protocol: '0.7.0' + postfix,
+  protocol: '0.8.0' + postfix,
   software: require('../package').version
 };
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ip": "^1.1.2",
     "jsen": "^0.6.0",
     "json-stable-stringify": "^1.0.1",
-    "kad": "^1.5.15",
+    "kad": "^1.5.16",
     "kad-quasar": "^0.1.3",
     "knuth-shuffle": "^1.0.1",
     "leveldown": "^1.4.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "implementation of the storj protocol for node.js and the browser",
   "main": "index.js",
   "directories": {

--- a/test/datachannel/client.unit.js
+++ b/test/datachannel/client.unit.js
@@ -6,6 +6,9 @@ var DataChannelClient = proxyquire('../../lib/datachannel/client', {
   ws: require('events').EventEmitter
 });
 var sinon = require('sinon');
+var DataChannelPointer = require('../../lib/datachannel/pointer');
+var Contact = require('../../lib/network/contact');
+var utils = require('../../lib/utils');
 
 describe('DataChannelClient', function() {
 
@@ -171,6 +174,42 @@ describe('DataChannelClient#getChannelURL', function() {
       address: ' 127.0.0.1  ',
       port: 1337
     })).to.equal('ws://127.0.0.1:1337');
+  });
+
+});
+
+describe('DataChannelClient#getStreamFromPointer', function() {
+
+  it('should return a readable stream for PULL pointer', function(done) {
+    var pointer = new DataChannelPointer(
+      Contact({ address: '127.0.0.1', port: 1337, nodeID: utils.rmd160('') }),
+      utils.rmd160('hash'),
+      utils.generateToken(),
+      'PULL'
+    );
+    var dcx = DataChannelClient.getStreamFromPointer(pointer, function(err, s) {
+      expect(typeof s.read).to.equal('function');
+      done();
+    });
+    setImmediate(function() {
+      dcx.emit('open');
+    });
+  });
+
+  it('should return a writable stream for PUSH pointer', function(done) {
+    var pointer = new DataChannelPointer(
+      Contact({ address: '127.0.0.1', port: 1337, nodeID: utils.rmd160('') }),
+      utils.rmd160('hash'),
+      utils.generateToken(),
+      'PUSH'
+    );
+    var dcx = DataChannelClient.getStreamFromPointer(pointer, function(err, s) {
+      expect(typeof s.write).to.equal('function');
+      done();
+    });
+    setImmediate(function() {
+      dcx.emit('open');
+    });
   });
 
 });

--- a/test/datachannel/pointer.unit.js
+++ b/test/datachannel/pointer.unit.js
@@ -1,0 +1,81 @@
+'use strict';
+
+var DataChannelPointer = require('../../lib/datachannel/pointer');
+var Contact = require('../../lib/network/contact');
+var utils = require('../../lib/utils');
+var expect = require('chai').expect;
+
+describe('DataChannelPointer', function() {
+
+  describe('@constructor', function() {
+
+    it('should create an instance without the new keyword', function() {
+      expect(DataChannelPointer(
+        Contact({
+          address: '127.0.0.1',
+          port: 1337,
+          nodeID: utils.rmd160('nodeid')
+        }),
+        utils.rmd160('hash'),
+        utils.generateToken(),
+        'PUSH'
+      )).to.be.instanceOf(DataChannelPointer);
+    });
+
+    it('should create an instance with the new keyword', function() {
+      expect(new DataChannelPointer(
+        Contact({
+          address: '127.0.0.1',
+          port: 1337,
+          nodeID: utils.rmd160('nodeid')
+        }),
+        utils.rmd160('hash'),
+        utils.generateToken()
+      )).to.be.instanceOf(DataChannelPointer);
+    });
+
+    it('should throw with invalid contact', function() {
+      expect(function() {
+        DataChannelPointer(
+          {
+            address: '127.0.0.1',
+            port: 1337,
+            nodeID: utils.rmd160('nodeid')
+          },
+          utils.rmd160('hash'),
+          utils.generateToken()
+        );
+      }).to.throw(Error, 'Invalid contact supplied');
+    });
+
+    it('should throw with invalid hash', function() {
+      expect(function() {
+        DataChannelPointer(
+          Contact({
+            address: '127.0.0.1',
+            port: 1337,
+            nodeID: utils.rmd160('nodeid')
+          }),
+          'hash',
+          utils.generateToken()
+        );
+      }).to.throw(Error, 'Invalid hash supplied');
+    });
+
+    it('should throw with invalid token', function() {
+      expect(function() {
+        DataChannelPointer(
+          Contact({
+            address: '127.0.0.1',
+            port: 1337,
+            nodeID: utils.rmd160('nodeid')
+          }),
+          utils.rmd160('hash'),
+          'token'
+        );
+      }).to.throw(Error, 'Invalid token supplied');
+    });
+
+  });
+
+});

--- a/test/interfaces/renter.unit.js
+++ b/test/interfaces/renter.unit.js
@@ -12,6 +12,7 @@ var StorageItem = require('../../lib/storage/item');
 var RAMStorageAdapter = require('../../lib/storage/adapters/ram');
 var Manager = require('../../lib/manager');
 var AuditStream = require('../../lib/auditstream');
+var DataChannelPointer = require('../../lib/datachannel/pointer');
 
 describe('RenterInterface', function() {
 
@@ -295,6 +296,41 @@ describe('RenterInterface', function() {
       }), Contract({}), function(err) {
         _send.restore();
         expect(err.message).to.equal('FAILED');
+        done();
+      });
+    });
+
+  });
+
+  describe('#getMirrorNodes', function() {
+
+    it('should callback error if all nodes fail', function(done) {
+      var renter = new RenterInterface({
+        keypair: KeyPair(),
+        port: 0,
+        noforward: true,
+        logger: kad.Logger(0),
+        manager: Manager(RAMStorageAdapter())
+      });
+      var _send = sinon.stub(renter._transport, 'send').callsArgWith(
+        2,
+        new Error('Send failed')
+      );
+      renter.getMirrorNodes([DataChannelPointer(
+        Contact({
+          address: '0.0.0.0',
+          port: 0,
+          nodeID: utils.rmd160('contact')
+        }),
+        utils.rmd160('hash'),
+        utils.generateToken()
+      )], [Contact({
+        address: '0.0.0.0',
+        port: 0,
+        nodeID: utils.rmd160('contact')
+      })], function(err) {
+        _send.restore();
+        expect(err.message).to.equal('All mirror requests failed');
         done();
       });
     });

--- a/test/network/index.integration.js
+++ b/test/network/index.integration.js
@@ -205,6 +205,7 @@ describe('Network/Integration/Tunnelling', function() {
 
     it('should get successful mirrors', function(done) {
       this.timeout(12000);
+      kad.constants.T_RESPONSETIMEOUT = 6000;
       var _negotiator = sinon.stub(farmers[0], '_negotiator').returns(false);
       renter.getStorageOffer(contract, function(_farmer) {
         _negotiator.restore();

--- a/test/network/index.integration.js
+++ b/test/network/index.integration.js
@@ -62,7 +62,7 @@ function createFarmer() {
 }
 
 var renters = [createRenter(), createRenter()];
-var farmers = [createFarmer()];
+var farmers = [createFarmer(), createFarmer()];
 
 before(function(done) {
   this.timeout(35000);
@@ -185,6 +185,14 @@ describe('Network/Integration/Tunnelling', function() {
         expect(v[0]).to.equal(v[1]);
         done();
       });
+    });
+
+  });
+
+  describe('getMirrorNodes', function() {
+
+    it('should get successful mirrors', function(done) {
+
     });
 
   });

--- a/test/network/index.integration.js
+++ b/test/network/index.integration.js
@@ -209,6 +209,7 @@ describe('Network/Integration/Tunnelling', function() {
       renter.getStorageOffer(contract, function(_farmer) {
         _negotiator.restore();
         renter.getRetrieveToken(farmer, contract, function(err, token) {
+          expect(err).to.equal(null);
           var pointers = [new DataChannelPointer(
             _farmer,
             contract.get('data_hash'),

--- a/test/network/index.integration.js
+++ b/test/network/index.integration.js
@@ -63,7 +63,7 @@ function createFarmer() {
 }
 
 var renters = [createRenter(), createRenter()];
-var farmers = [createFarmer(), createFarmer()];
+var farmers = [createFarmer()];
 
 before(function(done) {
   this.timeout(35000);
@@ -190,10 +190,18 @@ describe('Network/Integration/Tunnelling', function() {
 
   });
 
-  describe('getMirrorNodes', function() {
+  describe('#getMirrorNodes', function() {
+
+    before(function(done) {
+      this.timeout(10000);
+      createFarmer().join(done);
+    });
 
     it('should get successful mirrors', function(done) {
+      this.timeout(12000);
+      var _negotiator = sinon.stub(farmers[0], '_negotiator').returns(false);
       renter.getStorageOffer(contract, function(_farmer) {
+        _negotiator.restore();
         renter.getRetrieveToken(farmer, contract, function(err, token) {
           var pointers = [new DataChannelPointer(
             _farmer,
@@ -206,7 +214,6 @@ describe('Network/Integration/Tunnelling', function() {
             done();
           });
         });
-        done();
       });
     });
 

--- a/test/network/index.integration.js
+++ b/test/network/index.integration.js
@@ -13,6 +13,7 @@ var DataChannelClient = require('../../lib/datachannel/client');
 var StorageItem = require('../../lib/storage/item');
 var Verification = require('../../lib/verification');
 var memdown = require('memdown');
+var DataChannelPointer = require('../../lib/datachannel/pointer');
 
 kad.constants.T_RESPONSETIMEOUT = 2000;
 
@@ -192,7 +193,21 @@ describe('Network/Integration/Tunnelling', function() {
   describe('getMirrorNodes', function() {
 
     it('should get successful mirrors', function(done) {
-
+      renter.getStorageOffer(contract, function(_farmer) {
+        renter.getRetrieveToken(farmer, contract, function(err, token) {
+          var pointers = [new DataChannelPointer(
+            _farmer,
+            contract.get('data_hash'),
+            token,
+            'PULL'
+          )];
+          renter.getMirrorNodes(pointers, [_farmer], function(err, nodes) {
+            expect(nodes).to.have.lengthOf(1);
+            done();
+          });
+        });
+        done();
+      });
     });
 
   });

--- a/test/network/protocol.unit.js
+++ b/test/network/protocol.unit.js
@@ -344,6 +344,64 @@ describe('Protocol', function() {
 
   });
 
+  describe('#_handleMirror', function() {
+
+    it('should error if it fails to load', function(done) {
+      var proto = new Protocol({
+        network: {
+          _logger: Logger(0),
+          _manager: {
+            load: sinon.stub().callsArgWith(1, new Error('Failed'))
+          }
+        }
+      });
+      proto._handleMirror({}, function(err) {
+        expect(err.message).to.equal('Failed');
+        done();
+      });
+    });
+
+    it('should error if no contract found', function(done) {
+      var proto = new Protocol({
+        network: {
+          _logger: Logger(0),
+          _manager: {
+            load: sinon.stub().callsArgWith(1, null, { contracts: {} })
+          }
+        }
+      });
+      proto._handleMirror({
+        contact: { nodeID: 'test' }
+      }, function(err) {
+        expect(err.message).to.equal('No contract found for shard');
+        done();
+      });
+    });
+
+    it('should callback immediately if shard already exists', function(done) {
+      var proto = new Protocol({
+        network: {
+          _logger: Logger(0),
+          _manager: {
+            load: sinon.stub().callsArgWith(1, null, {
+              contracts: {
+                test: {}
+              },
+              shard: { read: sinon.stub() }
+            })
+          }
+        }
+      });
+      proto._handleMirror({
+        contact: { nodeID: 'test' }
+      }, function(err) {
+        expect(err).to.equal(null);
+        done();
+      });
+    });
+
+  });
+
   describe('#_handleProbe', function() {
 
     it('should respond with an error if probe fails', function(done) {


### PR DESCRIPTION
* Close #246 
* Close #221 
* Close #227
* Close #226
* Update the protocol specification
* Deprecate `RenterInterface#getConsignToken` and `RenterInterface#getRetrieveToken` in favor of `RenterInterface#getConsignmentPointer` and `RenterInterface#getRetrievalPointer`
* Add a `DataChannelPointer` class