### PR TITLE
v1.3.6 (Tunnel Verification)

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ module.exports.Transport = require('./lib/network/transport');
 /** {@link Contact} */
 module.exports.Contact = require('./lib/network/contact');
 
+/** {@link ContactChecker} */
+module.exports.ContactChecker = require('./lib/network/contactchecker');
+
 /** {@link RateLimiter} */
 module.exports.RateLimiter = require('./lib/network/ratelimiter');
 

--- a/lib/bridgeclient.js
+++ b/lib/bridgeclient.js
@@ -290,7 +290,7 @@ BridgeClient.prototype.addShardToFileStagingFrame = function(f, s, opt, cb) {
 
   if (typeof arguments[2] === 'function') {
     cb = opt;
-    opt = { retry: 3 };
+    opt = { retry: 6 };
   }
 
   function _addShard() {

--- a/lib/network/contactchecker.js
+++ b/lib/network/contactchecker.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var Contact = require('./contact');
+var net = require('net');
+var assert = require('assert');
+var merge = require('merge');
+
+/**
+ * Handles checking if a contact is reachable
+ * @constructor
+ * @param {Object} options
+ * @param {Number} options.timeout
+ * @extends {EventEmitter}
+ */
+function ContactChecker(options) {
+  if (!(this instanceof ContactChecker)) {
+    return new ContactChecker(options);
+  }
+
+  this._options = merge(Object.create(ContactChecker.DEFAULTS), options);
+}
+
+ContactChecker.DEFAULTS = {
+  timeout: 2000
+};
+
+/**
+ * Opens a connection to the contact to ensure it's reachable
+ * @param {Contact} contact - The contact to check
+ * @param {Function} callback -
+ */
+ContactChecker.prototype.check = function(contact, callback) {
+  assert(contact instanceof Contact, 'Invalid contact supplied');
+
+  var conn = null;
+  var timeout = setTimeout(function() {
+    conn.destroy();
+    callback(new Error('Host is not reachable'));
+  }, this._options.timeout);
+
+  function _connectListener() {
+    clearTimeout(timeout);
+    conn.destroy();
+    callback(null);
+  }
+
+  function _errorListener(err) {
+    clearTimeout(timeout);
+    conn.destroy();
+    callback(err);
+  }
+
+  conn = net.connect(contact.port, contact.address, _connectListener);
+
+  conn.on('error', _errorListener);
+};
+
+module.exports = ContactChecker;

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -644,6 +644,7 @@ Network.prototype._findTunnel = function(neighbors, callback) {
  */
 Network.prototype._establishTunnel = function(tunnels, callback) {
   var self = this;
+  var neighbors = this._options.seeds.map(this._createContact);
   var tunnel = null;
   var alias = null;
 
@@ -690,16 +691,20 @@ Network.prototype._establishTunnel = function(tunnels, callback) {
       self._contact.address = alias.address;
       self._contact.port = alias.port;
 
-      self._listenForTunnelers();
-      callback();
+      self._logger.info('testing newly established tunnel', alias);
+      self._requestProbe(neighbors[0], function(err, result) {
+        if (err || result.error) {
+          self._logger.warn('tunnel probe failed, establishing new tunnel');
+          return tunclient.close();
+        }
+
+        self._listenForTunnelers();
+        callback();
+      });
     });
 
-    tunclient.on('close', function onTunnelClosed(code, message) {
-      self._logger.warn(
-        'tunnel connection closed: %s / %s',
-        code,
-        message
-      );
+    tunclient.on('close', function onTunnelClosed() {
+      self._logger.warn('tunnel connection closed');
       self._establishTunnel(tunnels, callback);
     });
 

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -23,6 +23,7 @@ var RateLimiter = require('./ratelimiter');
 var ms = require('ms');
 var shuffle = require('knuth-shuffle').knuthShuffle;
 var BridgeClient = require('../bridgeclient');
+var ContactChecker = require('./contactchecker');
 
 /**
  * Storj network interface
@@ -644,7 +645,6 @@ Network.prototype._findTunnel = function(neighbors, callback) {
  */
 Network.prototype._establishTunnel = function(tunnels, callback) {
   var self = this;
-  var neighbors = this._options.seeds.map(this._createContact);
   var tunnel = null;
   var alias = null;
 
@@ -685,6 +685,7 @@ Network.prototype._establishTunnel = function(tunnels, callback) {
 
     var local = 'http://127.0.0.1:' + self._transport._server.address().port;
     var tunclient = new TunnelClient(tunnel, local);
+    var checker = new ContactChecker();
 
     tunclient.on('open', function() {
       self._logger.info('tunnel successfully established: %j', alias);
@@ -692,9 +693,9 @@ Network.prototype._establishTunnel = function(tunnels, callback) {
       self._contact.port = alias.port;
 
       self._logger.info('testing newly established tunnel', alias);
-      self._requestProbe(neighbors[0], function(err, result) {
-        if (err || result.error) {
-          self._logger.warn('tunnel probe failed, establishing new tunnel');
+      checker.check(self._contact, function(err) {
+        if (err) {
+          self._logger.warn('tunnel test failed, establishing new tunnel');
           return tunclient.close();
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "implementation of the storj protocol for node.js and the browser",
   "main": "index.js",
   "directories": {

--- a/test/bridgeclient.unit.js
+++ b/test/bridgeclient.unit.js
@@ -815,7 +815,7 @@ describe('BridgeClient', function() {
           meta: 'data'
         }, function() {
           _request.restore();
-          expect(_request.callCount).to.equal(4);
+          expect(_request.callCount).to.equal(7);
           done();
         });
       });

--- a/test/network/contactchecker.unit.js
+++ b/test/network/contactchecker.unit.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+var expect = require('chai').expect;
+var proxyquire = require('proxyquire');
+var sinon = require('sinon');
+var ContactChecker = require('../../lib/network/contactchecker');
+var Contact = require('../../lib/network/contact');
+var utils = require('../../lib/utils');
+
+describe('ContactChecker', function() {
+
+  describe('@constructor', function() {
+
+    it('should create an instance without the new keyword', function() {
+      expect(ContactChecker()).to.be.instanceOf(ContactChecker);
+    });
+
+  });
+
+  describe('#check', function() {
+
+    it('should error if timeout', function(done) {
+      var ContactChecker = proxyquire('../../lib/network/contactchecker', {
+        net: {
+          connect: function() {
+            var c = new EventEmitter();
+            c.destroy = sinon.stub();
+            return c;
+          }
+        }
+      });
+      var checker = new ContactChecker({ timeout: 10 });
+      checker.check(Contact({
+        address: '127.0.0.1',
+        port: 1337,
+        nodeID: utils.rmd160('')
+      }), function(err) {
+        expect(err.message).to.equal('Host is not reachable');
+        done();
+      });
+    });
+
+    it('should bubble connection error', function(done) {
+      var ContactChecker = proxyquire('../../lib/network/contactchecker', {
+        net: {
+          connect: function() {
+            var c = new EventEmitter();
+            c.destroy = sinon.stub();
+            setTimeout(function() {
+              c.emit('error', new Error('Connection error'));
+            }, 50);
+            return c;
+          }
+        }
+      });
+      var checker = new ContactChecker();
+      checker.check(Contact({
+        address: '127.0.0.1',
+        port: 1337,
+        nodeID: utils.rmd160('')
+      }), function(err) {
+        expect(err.message).to.equal('Connection error');
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/network/index.integration.js
+++ b/test/network/index.integration.js
@@ -66,9 +66,15 @@ var farmers = [createFarmer()];
 
 before(function(done) {
   this.timeout(35000);
-  sinon.stub(farmers[0], '_requestProbe').callsArgWith(
-    1, new Error('Probe failed')
-  ); // NB: Force tunneling
+  var _requestProbeCalled = false;
+
+  sinon.stub(farmers[0], '_requestProbe', function(c, cb) {
+    if (!_requestProbeCalled) {
+      _requestProbeCalled = true;
+      return cb(new Error('Probe failed'));
+    }
+    cb(null, {});
+  }); // NB: Force tunneling
 
   async.each(renters, function(node, next) {
     node.join(function noop() {});

--- a/test/network/index.unit.js
+++ b/test/network/index.unit.js
@@ -1,14 +1,20 @@
 'use strict';
 
+var sinon = require('sinon');
 var expect = require('chai').expect;
 var proxyquire = require('proxyquire');
 var EventEmitter = require('events').EventEmitter;
-var Network = require('../../lib/network');
+var Network = proxyquire('../../lib/network', {
+  './contactchecker': function() {
+    var emitter = new EventEmitter();
+    emitter.check = sinon.stub().callsArgWith(1, null);
+    return emitter;
+  }
+});
 var Manager = require('../../lib/manager');
 var KeyPair = require('../../lib/keypair');
 var RAMStorageAdapter = require('../../lib/storage/adapters/ram');
 var kad = require('kad');
-var sinon = require('sinon');
 var version = require('../../lib/version');
 var utils = require('../../lib/utils');
 var version = require('../../lib/version');
@@ -690,7 +696,7 @@ describe('Network (private)', function() {
       });
     });
 
-    it('should try to re-establish tunnel on probe fail', function(done) {
+    it('should try to re-establish tunnel on check fail', function(done) {
       var emitter = new EventEmitter();
       emitter.open = function() {
         emitter.emit('open');
@@ -700,6 +706,11 @@ describe('Network (private)', function() {
       };
       var TunClientStubNetwork = proxyquire('../../lib/network', {
         '../tunnel/client': function() {
+          return emitter;
+        },
+        './contactchecker': function() {
+          var emitter = new EventEmitter();
+          emitter.check = sinon.stub().callsArgWith(1, new Error('Failed'));
           return emitter;
         }
       });
@@ -748,6 +759,11 @@ describe('Network (private)', function() {
       var TunClientStubNetwork = proxyquire('../../lib/network', {
         '../tunnel/client': function() {
           return emitter;
+        },
+        './contactchecker': function() {
+          var emitter = new EventEmitter();
+          emitter.check = sinon.stub().callsArgWith(1, null);
+          return emitter;
         }
       });
       var net = TunClientStubNetwork({
@@ -787,6 +803,11 @@ describe('Network (private)', function() {
       };
       var TunClientStubNetwork = proxyquire('../../lib/network', {
         '../tunnel/client': function() {
+          return emitter;
+        },
+        './contactchecker': function() {
+          var emitter = new EventEmitter();
+          emitter.check = sinon.stub().callsArgWith(1, null);
           return emitter;
         }
       });


### PR DESCRIPTION
* Send a probe message after establishing a tunnel to ensure it is working
* If the probe fails try another tunnel
* Close #223 
* Increase the default `BridgeClient#addShardToFileStagingFrame` retries to 6
* Perform new network walk after new tunnel is established 