### PR TITLE
validate UPnP WAN IP

### DIFF
--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -59,6 +59,11 @@ Transport.prototype._open = function(callback) {
 
   if (ip.isPublic(self._contact.address) || self._noforward) {
     self._isPublic = true;
+    if (ip.isPrivate(self._contact.address)) {
+      self._log.error(
+        'you are not bound to a public address, traversal strategies disabled.'
+      );
+    }
     return kad.transports.HTTP.prototype._open.call(self, callback);
   }
 
@@ -67,7 +72,7 @@ Transport.prototype._open = function(callback) {
   self._log.warn(
     'you are not bound to a public address, trying traversal strategies...'
   );
-  self._forwardPort(function(err, ip, port) {
+  self._forwardPort(function(err, wanip, port) {
     self._isPublic = !err;
 
     if (self._isPublic) {
@@ -76,7 +81,7 @@ Transport.prototype._open = function(callback) {
     }
 
     kad.transports.HTTP.prototype._open.call(self, callback);
-    self._contact.address = ip || self._contact.address;
+    self._contact.address = wanip || self._contact.address;
   });
 };
 
@@ -95,18 +100,23 @@ Transport.prototype.createPortMapping = function(port, callback) {
     ttl: 0
   }, function(err) {
     if (err) {
-      self._log.warn('could not connect to NAT device via UPnP');
+      self._log.warn('could not connect to NAT device via UPnP: %s', port);
       return callback(err);
     }
 
-    natupnpClient.externalIp(function(err, ip) {
+    natupnpClient.externalIp(function(err, wanip) {
       if (err) {
         self._log.warn('could not obtain public IP address');
         return callback(err);
       }
 
-      self._log.info('successfully traversed NAT via UPnP');
-      callback(null, ip, port);
+      if (ip.isPrivate(wanip)) {
+        self._log.warn('UPnP device has no public IP address: %s', wanip);
+        return callback(new Error('UPnP device has no public IP address'));
+      }
+
+      self._log.info('successfully traversed NAT via UPnP: %s:%s', wanip, port);
+      callback(null, wanip, port);
     });
   });
 };

--- a/test/network/transport.unit.js
+++ b/test/network/transport.unit.js
@@ -96,6 +96,31 @@ describe('Network/Transport', function() {
       });
     });
 
+    it('should bubble private ip error', function(done) {
+      var BadIPTransport = proxyquire('../../lib/network/transport', {
+        'nat-upnp': {
+          createClient: function() {
+            return {
+              portMapping: sinon.stub().callsArg(1),
+              externalIp: sinon.stub().callsArgWith(0, null, '127.0.0.1')
+            };
+          }
+        }
+      });
+      var transport = new BadIPTransport(Contact({
+        address: '127.0.0.1',
+        port: 0,
+        nodeID: KeyPair().getNodeID()
+      }));
+      transport.on('ready', function() {
+        expect(transport._isPublic).to.equal(false);
+        transport._forwardPort(function(err) {
+          expect(err.message).to.equal('UPnP device has no public IP address');
+          done();
+        });
+      });
+    });
+
     it('should bubble portfinder error', function(done) {
       var BadPortFinder = proxyquire('../../lib/network/transport', {
         portfinder: {


### PR DESCRIPTION
Some user are sitting behind 2 routers like https://github.com/Storj/core/issues/241. UPnP will return the private ip address of the first router. Port not open on the second router. -> Use tunnel connection.

Other user disabled UPnP in there CLI config but are using a private IP address. This is still allowed for unit tests but print out an error message for the user.