### PR TITLE
Improvements to DataChannel Timeouts

### DIFF
--- a/lib/data-channels/readable-stream.js
+++ b/lib/data-channels/readable-stream.js
@@ -24,7 +24,7 @@ function ReadableDataChannelStream(channel, token, hash) {
 
   this.isAuthenticated = false;
 
-  this._channel._client.on('message', this.push.bind(this));
+  this._channel._client.on('message', this._push.bind(this));
   this._channel._client.on('close', function(code, message) {
     if (code !== 1000) {
       self.emit('error', new Error(message));
@@ -35,6 +35,8 @@ function ReadableDataChannelStream(channel, token, hash) {
 
   ReadableStream.call(this);
 }
+
+ReadableDataChannelStream.MAX_TTFB = 5000; // NB: Time To First Byte
 
 /**
  * Triggered when a error occurs
@@ -68,8 +70,42 @@ ReadableDataChannelStream.prototype._read = function() {
       operation: 'PULL'
     }), function() {
       self.isAuthenticated = true;
+      self._createTTFBTimeout();
     });
   }
+};
+
+/**
+ * Proxies the underlying push method to clear TTFB timer
+ * @private
+ */
+ReadableDataChannelStream.prototype._push = function(bytes) {
+  this._clearTTFBTimeout();
+  this.push(bytes);
+};
+
+/**
+ * Creates a timeout for receiving the first bytes
+ * @private
+ */
+ReadableDataChannelStream.prototype._createTTFBTimeout = function() {
+  var self = this;
+
+  this._ttfbTimeout = setTimeout(function() {
+    self.emit(
+      'error',
+      new Error('Did not receive data within max Time-To-First-Byte')
+    );
+    self.destroy();
+  }, ReadableDataChannelStream.MAX_TTFB);
+};
+
+/**
+ * Destroys the timeout for receiving first bytes
+ * @private
+ */
+ReadableDataChannelStream.prototype._clearTTFBTimeout = function() {
+  clearTimeout(this._ttfbTimeout);
 };
 
 /**

--- a/lib/data-channels/writable-stream.js
+++ b/lib/data-channels/writable-stream.js
@@ -26,6 +26,7 @@ function WritableDataChannelStream(channel, token, hash) {
   this.isAuthenticated = false;
 
   this._channel._client.on('close', function(code, message) {
+    self._clearTTWATimeout();
     self._handleClosed(function(err) {
       if (err) {
         return self.emit('error', err);
@@ -37,6 +38,8 @@ function WritableDataChannelStream(channel, token, hash) {
 
   FlushWritable.call(this);
 }
+
+WritableDataChannelStream.MAX_TTWA = 5000; // NB: Time To Write Acknowledgement
 
 /**
  * Triggered when a error occurs
@@ -79,15 +82,48 @@ WritableDataChannelStream.prototype._write = function(chunk, enc, callback) {
 WritableDataChannelStream.prototype._flush = function(callback) {
   var self = this;
 
+  function _flush(code, message) {
+    self._clearTTWATimeout();
+    self._handleClosed.call(
+      self._channel._client,
+      callback,
+      code,
+      message
+    );
+  }
+
   if (self._channel._client.readyState !== WebSocketClient.CLOSED) {
     self._channel._client.removeAllListeners('close');
-    self._channel._client.on('close', self._handleClosed.bind(
-      self._channel._client,
-      callback
-    ));
+    self._channel._client.on('close', _flush);
+    self._createTTWATimeout();
   } else {
     callback(null);
   }
+};
+
+/**
+ * Create a timeout for the remote host to acknowledge data was written
+ * @private
+ */
+WritableDataChannelStream.prototype._createTTWATimeout = function() {
+  var self = this;
+
+  this._ttwaTimeout = setTimeout(function() {
+    self.removeAllListeners('close');
+    self.destroy();
+    self.emit(
+      'error',
+      new Error('Did not close channel by max Time-To-Write-Acknowledgement')
+    );
+  }, WritableDataChannelStream.MAX_TTWA);
+};
+
+/**
+ * Clears the timeout for TTWA
+ * @private
+ */
+WritableDataChannelStream.prototype._clearTTWATimeout = function() {
+  clearTimeout(this._ttwaTimeout);
 };
 
 /**

--- a/test/data-channels/writable-stream.unit.js
+++ b/test/data-channels/writable-stream.unit.js
@@ -27,6 +27,32 @@ describe('WritableDataChannelStream', function() {
 
   });
 
+  describe('#write', function() {
+
+    it('should emit error if no write ack after flush', function(done) {
+      WritableStream.MAX_TTWA = 50;
+      var channel = new EventEmitter();
+      channel.readyState = 1;
+      channel.send = function(data, opts, cb) {
+        if (typeof opts === 'function') {
+          opts();
+        } else if (typeof cb === 'function') {
+          cb();
+        }
+      };
+      var ws = new WritableStream({ _client: channel });
+      ws.on('error', function(err) {
+        WritableStream.MAX_TTWA = 5000;
+        expect(err.message).to.equal(
+          'Did not close channel by max Time-To-Write-Acknowledgement'
+        );
+        done();
+      });
+      ws.end(Buffer('test data'));
+    });
+
+  });
+
   describe('#destroy', function() {
 
     it('should call terminate and set isDestroyed', function() {


### PR DESCRIPTION
* Add a TTFB (time-to-first-byte) timeout for reading from a datachannel
* Add a TTWA (time-to-write-acknowledgement) for writing to a datachannel
* Both values default to 5000ms
* If either is exceeded, an error is emitted (and handled via retry/renegotiation logic in `BridgeClient`)
* Closes #410 