### PR TITLE
fix socket hangup crash from tunnel client

### DIFF
--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -782,6 +782,7 @@ Network.prototype._establishTunnel = function(tunnels, callback) {
     }
 
     var tunnelWasOpened = false;
+    var tunnelDidError = false;
     var localAddress = self.transport._server.address();
 
     if (!localAddress) {
@@ -822,13 +823,23 @@ Network.prototype._establishTunnel = function(tunnels, callback) {
       self._establishTunnel(tunnels, tunnelWasOpened ? utils.noop : callback);
     });
 
-    self._tunnelClient.on('error', function onTunnelError(err) {
-      self._logger.warn(
-        'tunnel connection lost, reason: %s',
-        err.message
-      );
-      self._tunnelClient.removeAllListeners();
-      self._establishTunnel(tunnels, tunnelWasOpened ? utils.noop : callback);
+    self._tunnelClient.on('error', function onTunnelError(err) { 
+      self._tunnelClient.removeAllListeners('close');
+      
+      if (!tunnelDidError) {
+        tunnelDidError = true;
+
+        self._logger.warn(
+          'tunnel connection lost, reason: %s',
+          err.message
+        ); 
+        self._establishTunnel(tunnels, tunnelWasOpened ? utils.noop : callback);
+      } else {
+        self._log.debug(
+          'stale tunnel client encountered an error: %s, ignoring', 
+          err.message
+        );
+      }
     });
 
     self._tunnelClient.open();


### PR DESCRIPTION
sometimes a tunnel client can encounter more than one error and the network class removes all the listeners when the first error event is triggered causing subsequent errors triggered to throw.