### PR TITLE
Add configurable retry mechanism for entering overlay network

### DIFF
--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -118,7 +118,7 @@ inherits(Network, EventEmitter);
 Network.DEFAULTS = {
   bridgeUri: 'https://api.storj.io',
   seedList: [],
-  joinRetry: { times: 5, interval: 5000 },
+  joinRetry: { times: 1, interval: 5000 },
   rpcAddress: '127.0.0.1',
   rpcPort: 4000,
   doNotTraverseNat: false,
@@ -223,12 +223,12 @@ Network.prototype.join = function(callback) {
 
       // enter overlay network and retry if failed
       async.retry(
-          {
-            times: self._options.joinRetry.times,
-            interval: self._options.joinRetry.interval
-          },
-          self._enterOverlay.bind(self),
-          onJoinComplete
+        {
+          times: self._options.joinRetry.times,
+          interval: self._options.joinRetry.interval
+        },
+        self._enterOverlay.bind(self),
+        onJoinComplete
       );
     }
   );

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -118,6 +118,7 @@ inherits(Network, EventEmitter);
 Network.DEFAULTS = {
   bridgeUri: 'https://api.storj.io',
   seedList: [],
+  joinRetry: { times: 5, interval: 5000 },
   rpcAddress: '127.0.0.1',
   rpcPort: 4000,
   doNotTraverseNat: false,
@@ -220,7 +221,15 @@ Network.prototype.join = function(callback) {
         return self.emit('error', err);
       }
 
-      self._enterOverlay(onJoinComplete);
+      // enter overlay network and retry if failed
+      async.retry(
+          {
+            times: self._options.joinRetry.times,
+            interval: self._options.joinRetry.interval
+          },
+          self._enterOverlay.bind(self),
+          onJoinComplete
+      );
     }
   );
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
     {
       "name": "Alex Leitner",
       "url": "https://github.com/aleitner"
+    },
+    {
+      "name": "dxhome",
+      "url": "https://github.com/dxhome"
     }
   ],
   "license": "(AGPL-3.0 AND LGPL-3.0)",


### PR DESCRIPTION
The current network logic in core tights kad node creation and joining together, so it is hard to create a brand-new overlay network if there is no a valid seed.

Add such retry mechanism to allow one node to wait for other node to startup and connect to it. 

Passed all unit testing as below.
==========================
npm test

  ...
  666 passing (26s)


> storj-lib@4.0.1 linter /root/work/storj/sj-core
> jshint --config .jshintrc ./index.js ./lib ./test
