### PR TITLE
Use mnemonic seed

### DIFF
--- a/lib/crypto-tools/deterministic-key-iv.js
+++ b/lib/crypto-tools/deterministic-key-iv.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var assert = require('assert');
 var utils = require('../utils');
 
 /**
@@ -25,7 +26,9 @@ function DeterministicKeyIv(fileKey, fileId) {
  * @returns {String}
  */
 DeterministicKeyIv.getDeterministicKey = function(key, id){
-  var buffer = utils.sha512(key + id);
+  assert(Buffer.isBuffer(key), 'key is expected to a buffer');
+  assert(Buffer.isBuffer(id), 'id is expected to be a buffer');
+  var buffer = utils.sha512(Buffer.concat([key, id]));
   return buffer.toString('hex').substring(0, 64);
 };
 

--- a/lib/crypto-tools/keyring.js
+++ b/lib/crypto-tools/keyring.js
@@ -11,7 +11,6 @@ var os = require('os');
 var utils = require('../utils');
 var constants = require('../constants');
 var Mnemonic = require('bitcore-mnemonic');
-var unorm = require('unorm');
 
 /**
  * A {@link DataCipherKeyIv} factory with file system persistence
@@ -294,7 +293,10 @@ KeyRing.prototype.generateBucketKey = function(bucketId) {
   if (!this._mnemonic || !bucketId) {
     return null;
   }
-  return DeterministicKeyIv.getDeterministicKey(this._mnemonic, bucketId);
+  return DeterministicKeyIv.getDeterministicKey(
+    this._mnemonic.toSeed(),
+    new Buffer(bucketId, 'hex')
+  );
 };
 
 /**
@@ -311,7 +313,10 @@ KeyRing.prototype.generateFileKey = function(bucketId, fileId) {
     return DataCipherKeyIv();
   }
 
-  var fileKey = DeterministicKeyIv.getDeterministicKey(bucketKey, fileId);
+  var fileKey = DeterministicKeyIv.getDeterministicKey(
+    new Buffer(bucketKey, 'hex'),
+    new Buffer(fileId, 'hex')
+  );
   return new DeterministicKeyIv(fileKey, fileId);
 };
 
@@ -324,7 +329,7 @@ KeyRing.prototype._readDeterministicKey = function() {
     return;
   }
   var enc = fs.readFileSync(this._deterministicKeyFile).toString();
-  this._mnemonic = JSON.parse(this._decrypt(enc)).mnemonic;
+  this._mnemonic = new Mnemonic(JSON.parse(this._decrypt(enc)).mnemonic);
 };
 
 /**
@@ -337,8 +342,10 @@ KeyRing.prototype.generateDeterministicKey = function() {
     'Deterministic key already exists'
   );
 
-  this._mnemonic = new Mnemonic(Mnemonic.Words.ENGLISH).toString();
-  this._saveKeyToDisk('.deterministic_key', { mnemonic: this._mnemonic });
+  this._mnemonic = new Mnemonic(Mnemonic.Words.ENGLISH);
+  this._saveKeyToDisk('.deterministic_key', {
+    mnemonic: this._mnemonic.toString()
+  });
 };
 
 /**
@@ -352,12 +359,12 @@ KeyRing.prototype.importMnemonic = function(mnemonic) {
     'Deterministic key already exists'
   );
 
-  mnemonic = unorm.nfkd(mnemonic);
-
   assert(Mnemonic.isValid(mnemonic), 'Mnemonic is invalid');
 
-  this._mnemonic = mnemonic;
-  this._saveKeyToDisk('.deterministic_key', { mnemonic: this._mnemonic });
+  this._mnemonic = new Mnemonic(mnemonic);
+  this._saveKeyToDisk('.deterministic_key', {
+    mnemonic: this._mnemonic.toString()
+  });
 };
 
 /**
@@ -368,7 +375,7 @@ KeyRing.prototype.exportMnemonic = function() {
   if (!this._mnemonic) {
     return null;
   }
-  return this._mnemonic;
+  return this._mnemonic.toString();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -94,8 +94,7 @@
     "rimraf": "^2.5.3",
     "secp256k1": "^3.2.2",
     "semver": "^5.1.0",
-    "through": "^2.3.8",
-    "unorm": "^1.4.1"
+    "through": "^2.3.8"
   },
   "devDependencies": {
     "benchmark": "^2.1.1",

--- a/test/crypto-tools/deterministic-key-iv.unit.js
+++ b/test/crypto-tools/deterministic-key-iv.unit.js
@@ -45,11 +45,13 @@ describe('DeterministicKeyIv#fromObject', function() {
 describe('DeterministicKeyIv#getDeterministicKey', function() {
 
   it('should generate an deterministic key', function() {
-    var seed = '0123456789ab0123456789ab';
-    var bucketId = '0123456789ab';
+    var seed = new Buffer('5eb00bbddcf069084889a8ab9155568165f5c453ccb85e708' +
+                          '11aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43d' +
+                          'aea6690f20ad3d8d48b2d2ce9e38e4', 'hex');
+    var bucketId = new Buffer('0123456789ab0123456789ab', 'hex');
     var bucketKey = DeterministicKeyIv.getDeterministicKey(seed, bucketId);
-    var bucketKeyStart = 'ba24525';
-    expect(bucketKey.startsWith(bucketKeyStart)).to.equal(true);
+    expect(bucketKey).to.equal('b2464469e364834ad21e24c64f637c39083af5067693'+
+                               '605c84e259447644f6f6');
   });
 
 });

--- a/test/crypto-tools/keyring.unit.js
+++ b/test/crypto-tools/keyring.unit.js
@@ -374,16 +374,26 @@ describe('KeyRing', function() {
 
     describe('#_readDeterministicKey', function() {
 
-      var tmp = tmpfolder();
-      var kr = new KeyRing(tmp, 'password');
-
       it('should decrypt and read deterministic key', function(done) {
+        var tmp = tmpfolder();
+        var kr = new KeyRing(tmp, 'password');
         kr.generateDeterministicKey();
         var oldMnemonic = kr._mnemonic;
-        kr._mnemonic = '';
+        kr._mnemonic = null;
         kr._readDeterministicKey();
         expect(kr._mnemonic).to.eql(oldMnemonic);
         done();
+      });
+
+      it('should fail to decrypt', function() {
+        var tmp = tmpfolder();
+        var kr = new KeyRing(tmp, 'password');
+        kr.generateDeterministicKey();
+
+        expect(function() {
+          var kr2 = new KeyRing(tmp, 'badpassword');
+          kr2._readDeterministicKey();
+        }).to.throw('Invalid passphrase was supplied to KeyRing');
       });
 
     });

--- a/test/crypto-tools/keyring.unit.js
+++ b/test/crypto-tools/keyring.unit.js
@@ -3,6 +3,7 @@
 var KeyRing = require('../../lib/crypto-tools/keyring');
 var DataCipherKeyIv = require('../../lib/crypto-tools/cipher-key-iv');
 var DeterministicKeyIv = require('../../lib/crypto-tools/deterministic-key-iv');
+var Mnemonic = require('bitcore-mnemonic');
 var expect = require('chai').expect;
 var path = require('path');
 var fs = require('fs');
@@ -357,8 +358,10 @@ describe('KeyRing', function() {
       it('should create a valid deterministic key', function() {
         kr.generateDeterministicKey();
         expect(fs.existsSync(deterministicKeyPath)).to.equal(true);
-        expect(typeof kr._mnemonic).to.equal('string');
-        expect(kr._mnemonic.split(' ').length).to.equal(12);
+        expect(typeof kr._mnemonic).to.equal('object');
+        expect(kr._mnemonic).to.be.instanceOf(Mnemonic);
+
+        expect(kr._mnemonic.phrase.split(' ').length).to.equal(12);
       });
 
       it('should not allow overwriting a key', function() {
@@ -379,7 +382,7 @@ describe('KeyRing', function() {
         var oldMnemonic = kr._mnemonic;
         kr._mnemonic = '';
         kr._readDeterministicKey();
-        expect(kr._mnemonic).to.equal(oldMnemonic);
+        expect(kr._mnemonic).to.eql(oldMnemonic);
         done();
       });
 
@@ -435,11 +438,11 @@ describe('KeyRing', function() {
           'benefit marriage junk empower ' +
           'bag blind divide stereo';
         kr.importMnemonic(mnemonic);
-        expect(kr._mnemonic).to.equal(mnemonic);
+        expect(kr._mnemonic.phrase).to.equal(mnemonic);
 
         kr._mnemonic = '';
         kr._readDeterministicKey();
-        expect(kr._mnemonic).to.equal(mnemonic);
+        expect(kr._mnemonic.phrase).to.equal(mnemonic);
         done();
       });
 
@@ -456,13 +459,28 @@ describe('KeyRing', function() {
     });
 
     describe('#generateBucketKey', function() {
+      var sandbox = sinon.sandbox.create();
+      afterEach(function() {
+        sandbox.restore();
+      });
       var tmp = tmpfolder();
       var kr = new KeyRing(tmp, 'password');
-      kr._mnemonic = 'test test test';
+      kr._mnemonic = new Mnemonic('abandon abandon abandon abandon abandon '+
+                                  'abandon abandon abandon abandon abandon '+
+                                  'abandon about');
       it('should generate the expected bucket key', function() {
         var bucketId = '0123456789ab0123456789ab';
+        sandbox.spy(DeterministicKeyIv, 'getDeterministicKey');
         var bucketKey = kr.generateBucketKey(bucketId);
-        expect(bucketKey.startsWith('c79dbe80')).to.equal(true);
+
+        expect(DeterministicKeyIv.getDeterministicKey.callCount).to.equal(1);
+        expect(
+          DeterministicKeyIv.getDeterministicKey.args[0][0].toString('hex')
+        ).to.equal('5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f' +
+                   '6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d' +
+                   '48b2d2ce9e38e4');
+        expect(bucketKey).to.equal('b2464469e364834ad21e24c64f637c39083af5067' +
+                                   '693605c84e259447644f6f6');
       });
 
       it('should return null without mnemonic', function() {
@@ -477,14 +495,16 @@ describe('KeyRing', function() {
     describe('#generateFileKey', function() {
       var tmp = tmpfolder();
       var kr = new KeyRing(tmp, 'password');
-      kr._mnemonic = 'test test test';
+      kr._mnemonic = new Mnemonic('abandon abandon abandon abandon abandon '+
+                                  'abandon abandon abandon abandon abandon '+
+                                  'abandon about');
       it('should generate the expected file key', function() {
         var bucketId = '0123456789ab';
         var fileId = '0123456789ab';
         var fileKey = kr.generateFileKey(bucketId, fileId);
-        var fileKeyStart = 'fea62b60';
         var fileKeyPassString = fileKey._pass.toString('hex');
-        expect(fileKeyPassString.startsWith(fileKeyStart)).to.equal(true);
+        expect(fileKeyPassString).to.equal('239596dd4de25d9e50c87e82ae401549c' +
+                                           '4a75221cfdb32a952a6cdfa41462152');
       });
 
       it('should generate a random file key', function() {


### PR DESCRIPTION
- Uses mnemonic seed (pbkdf2 hash of the mnemonic phrase) to determine bucketId instead of using the mnemonic phrase directly.
- Uses actual binary of fileId and bucketId hex value, instead of utf8 encoded hex values