### PR TITLE
Fix null reference

### DIFF
--- a/lib/network/protocol.js
+++ b/lib/network/protocol.js
@@ -321,7 +321,7 @@ Protocol.prototype.handleMirror = function(params, callback) {
 
     downloader.on('error', function _onStreamError(err) {
       self._logger.error('failed to read from mirror node: %s', err.message);
-      downloader.unpipe(item.shard);
+      downloader.destroy();
       item.shard.destroy(utils.noop);
     }).pipe(item.shard);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storj-lib",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "implementation of the storj protocol for node.js and the browser",
   "main": "index.js",
   "directories": {

--- a/test/network/protocol.unit.js
+++ b/test/network/protocol.unit.js
@@ -935,6 +935,7 @@ describe('Protocol', function() {
 
     it('should start downloading shard and destroy on failure', function(done) {
       var download = new stream.Readable({ read: () => null });
+      download.destroy = sinon.stub();
       var Protocol = proxyquire('../../lib/network/protocol', {
         '../utils': {
           createShardDownloader: sinon.stub().returns(download)
@@ -971,6 +972,7 @@ describe('Protocol', function() {
         download.emit('error', new Error());
         setImmediate(() => {
           expect(shard.destroy.called).to.equal(true);
+          expect(download.destroy.called).to.equal(true);
           done();
         });
       });


### PR DESCRIPTION
The request object returned is not a standard stream and does not implement `unpipe`. Use `destroy` instead.

* Closes https://github.com/Storj/storjshare-cli/issues/225