### PR TITLE
reducing the amount of keep-alive packages

### DIFF
--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -245,7 +245,7 @@ Transport.prototype._send = function(data, contact) {
       'content-type': 'application/json',
       'x-storj-node-id': contact.nodeID
     },
-    agent: new http.Agent({ keepAlive: true }),
+    agent: new http.Agent({ keepAlive: true, keepAliveMsecs: 25000 }),
     // NB: Disable TCP Nagle algorithm - use `signRequest` options to
     // NB: manipulate the request object before sending
     signRequest: (req) => req.setNoDelay(true)


### PR DESCRIPTION
Keep-alive keeps the socket open by itself, the default value of 1000msec for sending an tcp package makes a large amount of packets.