### PR TITLE
getDeterministicKey updates

### DIFF
--- a/lib/crypto-tools/deterministic-key-iv.js
+++ b/lib/crypto-tools/deterministic-key-iv.js
@@ -20,14 +20,22 @@ function DeterministicKeyIv(fileKey, fileId) {
 }
 
 /**
- * Calculates a deterministic bucket key
- * @param {String} seed - Deterministic seed
- * @param {String} bucketId - Unique bucket id
+ * Calculates a deterministic key
+ * @param {Buffer|String} seed - Deterministic seed or bucket key
+ * @param {Buffer|String} id - Unique bucket or file id
  * @returns {String}
  */
 DeterministicKeyIv.getDeterministicKey = function(key, id){
-  assert(Buffer.isBuffer(key), 'key is expected to a buffer');
-  assert(Buffer.isBuffer(id), 'id is expected to be a buffer');
+  if (!Buffer.isBuffer(key)) {
+    assert(utils.isHexaString(key),
+           'key is expected to be a buffer or hex string');
+    key = Buffer.from(key, 'hex');
+  }
+  if (!Buffer.isBuffer(id)) {
+    assert(utils.isHexaString(id),
+           'id is expected to be a buffer or hex string');
+    id = Buffer.from(id, 'hex');
+  }
   var buffer = utils.sha512(Buffer.concat([key, id]));
   return buffer.toString('hex').substring(0, 64);
 };

--- a/lib/crypto-tools/keyring.js
+++ b/lib/crypto-tools/keyring.js
@@ -295,7 +295,7 @@ KeyRing.prototype.generateBucketKey = function(bucketId) {
   }
   return DeterministicKeyIv.getDeterministicKey(
     this._mnemonic.toSeed(),
-    new Buffer(bucketId, 'hex')
+    Buffer.from(bucketId, 'hex')
   );
 };
 
@@ -314,8 +314,8 @@ KeyRing.prototype.generateFileKey = function(bucketId, fileId) {
   }
 
   var fileKey = DeterministicKeyIv.getDeterministicKey(
-    new Buffer(bucketKey, 'hex'),
-    new Buffer(fileId, 'hex')
+    Buffer.from(bucketKey, 'hex'),
+    Buffer.from(fileId, 'hex')
   );
   return new DeterministicKeyIv(fileKey, fileId);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -167,6 +167,18 @@ module.exports.isValidContact = function(contact, loopback) {
 };
 
 /**
+ * Determines if a value is hexadecimal string
+ * @param {*} a - The value to be tested
+ * @returns {Boolean}
+ */
+module.exports.isHexaString = function(a) {
+  if (typeof a !== 'string') {
+    return false;
+  }
+  return /^[0-9a-fA-F]+$/.test(a);
+};
+
+/**
  * Creates an ECIES ciper object from a private and a public key
  * @param {String} privateKey - The private key of the sender
  * @param {String} publicKey - The public key of the recipient

--- a/test/crypto-tools/deterministic-key-iv.unit.js
+++ b/test/crypto-tools/deterministic-key-iv.unit.js
@@ -44,7 +44,7 @@ describe('DeterministicKeyIv#fromObject', function() {
 
 describe('DeterministicKeyIv#getDeterministicKey', function() {
 
-  it('should generate an deterministic key', function() {
+  it('should generate a deterministic key', function() {
     var seed = Buffer.from('5eb00bbddcf069084889a8ab9155568165f5c453ccb85e708' +
                            '11aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43d' +
                            'aea6690f20ad3d8d48b2d2ce9e38e4', 'hex');
@@ -54,7 +54,7 @@ describe('DeterministicKeyIv#getDeterministicKey', function() {
                                '605c84e259447644f6f6');
   });
 
-  it('should generate an deterministic key (using hex strings)', function() {
+  it('should generate a deterministic key (using hex strings)', function() {
     var seed = '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5' +
         'fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4';
     var bucketId = '0123456789ab0123456789ab';
@@ -84,7 +84,7 @@ describe('DeterministicKeyIv#getDeterministicKey', function() {
 
 describe('DeterministicKeyIv#getCipherKeyIv', function() {
 
-  it('should generate an deterministic key', function() {
+  it('should generate a deterministic key', function() {
     var keyiv1 = new DeterministicKeyIv('0123', '0123');
     var cipherIv = keyiv1.getCipherKeyIv();
     expect(cipherIv[0].toString('hex').startsWith('1be2e')).to.equal(true);

--- a/test/crypto-tools/deterministic-key-iv.unit.js
+++ b/test/crypto-tools/deterministic-key-iv.unit.js
@@ -45,13 +45,39 @@ describe('DeterministicKeyIv#fromObject', function() {
 describe('DeterministicKeyIv#getDeterministicKey', function() {
 
   it('should generate an deterministic key', function() {
-    var seed = new Buffer('5eb00bbddcf069084889a8ab9155568165f5c453ccb85e708' +
-                          '11aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43d' +
-                          'aea6690f20ad3d8d48b2d2ce9e38e4', 'hex');
-    var bucketId = new Buffer('0123456789ab0123456789ab', 'hex');
+    var seed = Buffer.from('5eb00bbddcf069084889a8ab9155568165f5c453ccb85e708' +
+                           '11aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43d' +
+                           'aea6690f20ad3d8d48b2d2ce9e38e4', 'hex');
+    var bucketId = Buffer.from('0123456789ab0123456789ab', 'hex');
     var bucketKey = DeterministicKeyIv.getDeterministicKey(seed, bucketId);
     expect(bucketKey).to.equal('b2464469e364834ad21e24c64f637c39083af5067693'+
                                '605c84e259447644f6f6');
+  });
+
+  it('should generate an deterministic key (using hex strings)', function() {
+    var seed = '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5' +
+        'fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4';
+    var bucketId = '0123456789ab0123456789ab';
+    var bucketKey = DeterministicKeyIv.getDeterministicKey(seed, bucketId);
+    expect(bucketKey).to.equal('b2464469e364834ad21e24c64f637c39083af5067693'+
+                               '605c84e259447644f6f6');
+  });
+
+  it('should throw with unexpected string for seed', function() {
+    var seed = 'not a hex string';
+    var bucketId = '0123456789ab0123456789ab';
+    expect(function() {
+      DeterministicKeyIv.getDeterministicKey(seed, bucketId);
+    }).to.throw('key is expected to be a buffer or hex string');
+  });
+
+  it('should throw with unexpected string for bucketId', function() {
+    var seed = '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5' +
+        'fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4';
+    var bucketId = 'not a hex string';
+    expect(function() {
+      DeterministicKeyIv.getDeterministicKey(seed, bucketId);
+    }).to.throw('id is expected to be a buffer or hex string');
   });
 
 });

--- a/test/utils.unit.js
+++ b/test/utils.unit.js
@@ -102,6 +102,47 @@ describe('utils', function() {
 
   });
 
+  describe('#isHexaString', function() {
+    it('returns false for object', function() {
+      expect(utils.isHexaString({})).to.equal(false);
+    });
+
+    it('returns false for number', function() {
+      expect(utils.isHexaString(123456789)).to.equal(false);
+    });
+
+    it('returns false for function', function() {
+      expect(utils.isHexaString(function(){})).to.equal(false);
+    });
+
+    it('returns false for json string', function() {
+      expect(utils.isHexaString('{"hello": "world"}')).to.equal(false);
+    });
+
+    it('returns false for base64 string', function() {
+      expect(utils.isHexaString('+rx4I0qmXs+I8TYn')).to.equal(false);
+    });
+
+    it('returns false for any string with non-base16 characters', function() {
+      ['g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
+       'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '!', '@',
+       '#', '$', '%', '^', '&', '*', '(', ')', 'G', 'H', 'I',
+       'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+       'U', 'V', 'W', 'X', 'Y', 'Z', '\'', '"'].forEach((a) => {
+         expect(utils.isHexaString(a)).to.equal(false);
+       });
+    });
+
+    it('returns true for hexadecimal string (lowercase)', function() {
+      expect(utils.isHexaString('0123456789abcdef')).to.equal(true);
+    });
+
+    it('returns true for hexadecimal string (uppercase)', function() {
+      expect(utils.isHexaString('0123456789ABCDEF')).to.equal(true);
+    });
+
+  });
+
   describe('#sha1whirlpool', function() {
 
     it('should return the hex encoded hash', function() {


### PR DESCRIPTION
- Update jsdocs
- Accept hexadecimal strings in addition to buffers in args
- Use `Buffer.from()` instead of deprecated `new Buffer()`
- Adds `isHexaString` util

Related: https://github.com/Storj/core/issues/589