### PR TITLE
Allow preflight CORS requests to farmers

### DIFF
--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -143,6 +143,8 @@ Transport.prototype._bindServer = function(callback) {
   self._server.use(self._routeTunnelProxies.bind(self));
   self._server.use(restify.CORS());
 
+  self._server.opts(/.*/, self._handleOpts.bind(self));
+
   // Routes
   self._server.post(
     '/',
@@ -161,6 +163,23 @@ Transport.prototype._bindServer = function(callback) {
   );
 
   self._server.listen(self._contact.port, callback);
+};
+
+/**
+ * _handleOpts handles incomming OPTIONS requests. These requests are preflight
+ * requests for Cross-Origin requests enforced by browser security. This
+ * function essentially allows all methods and headers for any origin, allowing
+ * any domain to make a request to a farmer.
+ * @private
+ */
+Transport.prototype._handleOpts = function(req, res, next) {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header('Access-Control-Allow-Methods',
+      req.header('Access-Control-Request-Method'));
+    res.header('Access-Control-Allow-Headers',
+      req.header('Access-Control-Request-Headers'));
+    res.send(200);
+    return next();
 };
 
 /**


### PR DESCRIPTION
Allows browsers to contact farmers directly over HTTP