### PR TITLE
feature: log blacklist entries

### DIFF
--- a/lib/bridge-client/blacklist.js
+++ b/lib/bridge-client/blacklist.js
@@ -11,17 +11,20 @@ var path = require('path');
  * @constructor
  * @license LGPL-3.0
  * @see https://github.com/storj/bridge
- * @param {String} path - blacklist folder location
+ * @param {String} options.blacklistFolder - blacklist folder location
+ * @param {Object} options.logger - Logger instance
  */
-function Blacklist(folder) {
+function Blacklist(options) {
   if (!(this instanceof Blacklist)) {
-    return new Blacklist(folder);
+    return new Blacklist(options);
   }
+  
+  assert.ok(utils.existsSync(options.blacklistFolder), 
+    'Invalid Blacklist Folder');
 
-  assert.ok(utils.existsSync(folder), 'Invalid Blacklist Folder');
-
-  this.blacklistFile = path.join(folder,'.blacklist');
+  this.blacklistFile = path.join(options.blacklistFolder,'.blacklist');
   this.blacklist = this._loadFromDisk();
+  this._logger = options.logger;
 }
 
 Blacklist.TTL = 86400000;
@@ -31,6 +34,7 @@ Blacklist.TTL = 86400000;
  * @param {String} nodeid - Node id to be added to blacklist
  */
 Blacklist.prototype.push = function(nodeid) {
+  this._logger.info('Adding NodeID %s to blacklist', nodeid);
   this.blacklist[nodeid] = Date.now();
   this._saveToDisk();
 };

--- a/lib/bridge-client/index.js
+++ b/lib/bridge-client/index.js
@@ -47,7 +47,7 @@ function BridgeClient(uri, options) {
   }
 
   this._options = this._checkOptions(uri, options);
-  this._blacklist = new Blacklist(this._options.blacklistFolder);
+  this._blacklist = new Blacklist(this._options);
   this._logger = this._options.logger;
   this._transferConcurrency = this._options.transferConcurrency;
 }

--- a/test/bridge-client/blacklist.unit.js
+++ b/test/bridge-client/blacklist.unit.js
@@ -5,6 +5,7 @@
 
 
 var Blacklist = require('../../lib/bridge-client/blacklist');
+var BridgeClient = require('../../lib/bridge-client');
 var fs = require('fs');
 var expect = require('chai').expect;
 var utils = require('../../lib/utils');
@@ -15,13 +16,14 @@ var tmpfolder = require('os').tmpdir();
 describe('Blacklist', function() {
 
   describe('@constructor', function() {
-
+    var client = BridgeClient();
+    client._options.blacklistFolder = tmpfolder;
     it('should create an instance without the new keyword', function() {
-      expect(Blacklist(tmpfolder)).to.be.instanceOf(Blacklist);
+      expect(Blacklist(client._options)).to.be.instanceOf(Blacklist);
     });
 
     it('should create an instance with the given path', function() {
-      var blacklist = new Blacklist(tmpfolder);
+      var blacklist = new Blacklist(client._options);
       expect(blacklist.blacklist).to.be.an('object');
       expect(utils.existsSync(blacklist.blacklistFile)).to.equal(true);
     });
@@ -31,7 +33,9 @@ describe('Blacklist', function() {
   describe('push', function() {
 
     it('should push the node id to an object with a timestamp', function() {
-      var blacklist = new Blacklist(tmpfolder);
+      var client = BridgeClient();
+      client._options.blacklistFolder = tmpfolder;
+      var blacklist = new Blacklist(client._options);
       blacklist.push('hi');
       expect(blacklist.blacklist.hi).to.not.be.undefined;
       fs.unlinkSync(blacklist.blacklistFile);
@@ -42,7 +46,9 @@ describe('Blacklist', function() {
   describe('toObject', function() {
 
     it('should create an instance with the given path', function() {
-      var blacklist = new Blacklist(tmpfolder);
+      var client = BridgeClient();
+      client._options.blacklistFolder = tmpfolder;
+      var blacklist = new Blacklist(client._options);
       blacklist.push('hi');
       blacklist.push('hi2');
       blacklist.push('hi3');
@@ -55,7 +61,9 @@ describe('Blacklist', function() {
   describe('_reap', function() {
 
     it('should reap old nodeids', function() {
-      var blacklist = new Blacklist(tmpfolder);
+      var client = BridgeClient();
+      client._options.blacklistFolder = tmpfolder;
+      var blacklist = new Blacklist(client._options);
       var clock = sinon.useFakeTimers();
       blacklist.push('hi');
       clock.tick(86400001);


### PR DESCRIPTION
This is a basic PR in reference to https://github.com/Storj/core-cli/issues/80

Let me know if calling an instance of the logger with the blacklist is the best approach. I could try refactoring the class to accept an options param like other classes. ``options.folder`` and ``options.logger``