### PR TITLE
tiny performance enhancement shard cleanup

### DIFF
--- a/lib/storage/manager.js
+++ b/lib/storage/manager.js
@@ -148,6 +148,7 @@ StorageManager.prototype.close = function(callback) {
 StorageManager.prototype.clean = function(callback) {
   var self = this;
   var rstream = this._storage.createReadStream();
+  var timestamp = Date.now();
 
   rstream.on('data', function(item) {
     rstream.pause();
@@ -156,7 +157,7 @@ StorageManager.prototype.clean = function(callback) {
     var endedOrIncomplete = 0;
 
     for (var nodeID in item.contracts) {
-      var ended = item.contracts[nodeID].get('store_end') < Date.now();
+      var ended = item.contracts[nodeID].get('store_end') < timestamp;
       var incomplete = !item.contracts[nodeID].isComplete();
 
       if (ended || incomplete) {


### PR DESCRIPTION
Call Date.now only once. The shard cleanup don't need a accurate timestamp for each shard. The same timestamp for all shards will work as well and needs less CPU cycles.