### PR TITLE
audit: use buffers when hashing

### DIFF
--- a/lib/audit-tools/audit-stream.js
+++ b/lib/audit-tools/audit-stream.js
@@ -123,7 +123,7 @@ AuditStream.prototype._generateTree = function() {
       const rmd2 = crypto.createHash('rmd160').update(sha).digest();
       return rmd2.toString('hex');
     }
-  }), utils.rmd160sha256);
+  }), utils.rmd160sha256b);
 };
 
 /**
@@ -160,7 +160,7 @@ AuditStream.fromRecords = function(challenges, tree) {
   var auditor = new AuditStream(challenges.length);
 
   auditor._challenges = challenges;
-  auditor._tree = new MerkleTree(tree, utils.rmd160sha256);
+  auditor._tree = new MerkleTree(tree, utils.rmd160sha256b);
   auditor._finished = true;
 
   return auditor;

--- a/lib/audit-tools/audit-stream.js
+++ b/lib/audit-tools/audit-stream.js
@@ -73,7 +73,7 @@ AuditStream.prototype._write = function(bytes, encoding, next) {
 
   this._inputs.forEach(function(input, i) {
     if (i < self._audits) {
-      input.update(bytes.toString('hex'));
+      input.update(bytes);
     }
   });
   next();
@@ -91,7 +91,7 @@ AuditStream.prototype._prepareChallenges = function() {
     var challenge = this._generateChallenge();
     var input = this._createResponseInput(challenge);
 
-    this._challenges.push(challenge);
+    this._challenges.push(challenge.toString('hex'));
     inputs.push(input);
 
     iterations++;
@@ -118,7 +118,10 @@ AuditStream.prototype._generateTree = function() {
     if (i >= self._audits) {
       return input;
     } else {
-      return utils.rmd160sha256(utils.rmd160(input.digest('hex')));
+      const rmd1 = crypto.createHash('rmd160').update(input.digest()).digest();
+      const sha = crypto.createHash('sha256').update(rmd1).digest();
+      const rmd2 = crypto.createHash('rmd160').update(sha).digest();
+      return rmd2.toString('hex');
     }
   }), utils.rmd160sha256);
 };
@@ -129,7 +132,7 @@ AuditStream.prototype._generateTree = function() {
  * @returns {String} Hex encoded random bytes
  */
 AuditStream.prototype._generateChallenge = function() {
-  return crypto.randomBytes(constants.AUDIT_BYTES).toString('hex');
+  return crypto.randomBytes(constants.AUDIT_BYTES);
 };
 
 /**

--- a/lib/audit-tools/audit-stream.js
+++ b/lib/audit-tools/audit-stream.js
@@ -61,7 +61,7 @@ AuditStream.prototype.getPrivateRecord = function() {
   return {
     root: this._tree.root(),
     depth: this._tree.levels(),
-    challenges: this._challenges
+    challenges: this._challenges.map((i) => i.toString('hex'))
   };
 };
 
@@ -92,7 +92,7 @@ AuditStream.prototype._prepareChallenges = function() {
     var challenge = this._generateChallenge();
     var input = this._createResponseInput(challenge);
 
-    this._challenges.push(challenge.toString('hex'));
+    this._challenges.push(challenge);
     inputs.push(input);
 
     iterations++;

--- a/lib/audit-tools/audit-stream.js
+++ b/lib/audit-tools/audit-stream.js
@@ -47,7 +47,8 @@ inherits(AuditStream, stream.Writable);
 AuditStream.prototype.getPublicRecord = function() {
   assert(this._finished, 'Challenge generation is not finished');
 
-  return this._tree.level(this._tree.levels() - 1);
+  return this._tree.level(this._tree.levels() - 1)
+    .map((i) => i.toString('hex'));
 };
 
 /**
@@ -98,7 +99,7 @@ AuditStream.prototype._prepareChallenges = function() {
   }
 
   while (iterations < utils.getNextPowerOfTwo(this._audits)) {
-    inputs.push(utils.rmd160sha256(''));
+    inputs.push(utils.rmd160sha256b(''));
     iterations++;
   }
 
@@ -121,7 +122,7 @@ AuditStream.prototype._generateTree = function() {
       const rmd1 = crypto.createHash('rmd160').update(input.digest()).digest();
       const sha = crypto.createHash('sha256').update(rmd1).digest();
       const rmd2 = crypto.createHash('rmd160').update(sha).digest();
-      return rmd2.toString('hex');
+      return rmd2;
     }
   }), utils.rmd160sha256b);
 };
@@ -156,6 +157,8 @@ AuditStream.fromRecords = function(challenges, tree) {
     tree.length === utils.getNextPowerOfTwo(challenges.length),
     'Challenges and tree do not match'
   );
+
+  tree = tree.map((i) => Buffer.from(i, 'hex'));
 
   var auditor = new AuditStream(challenges.length);
 

--- a/lib/audit-tools/proof-stream.js
+++ b/lib/audit-tools/proof-stream.js
@@ -23,8 +23,12 @@ function ProofStream(leaves, challenge) {
   assert(Array.isArray(leaves), 'Merkle leaves must be an array');
   assert.ok(challenge, 'Invalid challenge supplied');
 
-  this._tree = new MerkleTree(this._generateLeaves(leaves), utils.rmd160sha256);
-  this._challenge = challenge;
+  this._tree = new MerkleTree(this._generateLeaves(leaves), utils.rmd160sha256b);
+  if (!Buffer.isBuffer(challenge)) {
+    this._challenge = Buffer.from(challenge, 'hex');
+  } else {
+    this._challenge = challenge;
+  }
   this._hasher = crypto.createHash('sha256').update(this._challenge);
   this._proof = null;
 
@@ -48,7 +52,7 @@ ProofStream.prototype.getProofResult = function() {
  * @private
  */
 ProofStream.prototype._transform = function(chunk, encoding, next) {
-  this._hasher.update(chunk.toString('hex'));
+  this._hasher.update(chunk, encoding);
   next();
 };
 
@@ -74,9 +78,19 @@ ProofStream.prototype._flush = function(done) {
  * @returns {Array} result - Challenge response
  */
 ProofStream.prototype._generateProof = function() {
-  var response = utils.rmd160(this._hasher.digest('hex'));
+
+  var response = utils.rmd160b(this._hasher.digest());
   var leaves = this._tree.level(this._tree.levels() - 1);
-  var challengenum = leaves.indexOf(utils.rmd160sha256(response));
+
+  const leaf = utils.rmd160sha256b(response);
+
+  var challengenum = -1;
+  for (let i = 0; i < leaves.length; i++) {
+    if (Buffer.compare(leaves[i], leaf) === 0) {
+      challengenum = i;
+      break;
+    }
+  }
 
   assert(challengenum !== -1, 'Failed to generate proof');
 
@@ -107,8 +121,10 @@ ProofStream.prototype._generateLeaves = function(leaves) {
   var emptyLeaves = [];
 
   for (var i = 0; i < numEmpty; i++) {
-    emptyLeaves.push(utils.rmd160sha256(''));
+    emptyLeaves.push(utils.rmd160sha256b(''));
   }
+
+  leaves = leaves.map((i) => Buffer.from(i, 'hex'))
 
   return leaves.concat(emptyLeaves);
 };

--- a/lib/audit-tools/proof-stream.js
+++ b/lib/audit-tools/proof-stream.js
@@ -23,7 +23,8 @@ function ProofStream(leaves, challenge) {
   assert(Array.isArray(leaves), 'Merkle leaves must be an array');
   assert.ok(challenge, 'Invalid challenge supplied');
 
-  this._tree = new MerkleTree(this._generateLeaves(leaves), utils.rmd160sha256b);
+  this._tree = new MerkleTree(this._generateLeaves(leaves),
+                              utils.rmd160sha256b);
   if (!Buffer.isBuffer(challenge)) {
     this._challenge = Buffer.from(challenge, 'hex');
   } else {
@@ -71,6 +72,17 @@ ProofStream.prototype._flush = function(done) {
   done();
 };
 
+ProofStream.prototype._findMatchIndex = function(leaves, leaf) {
+  var challengenum = -1;
+  for (let i = 0; i < leaves.length; i++) {
+    if (Buffer.compare(leaves[i], leaf) === 0) {
+      challengenum = i;
+      break;
+    }
+  }
+  return challengenum;
+}
+
 /**
  * Calculate audit response
  * @private
@@ -84,13 +96,7 @@ ProofStream.prototype._generateProof = function() {
 
   const leaf = utils.rmd160sha256b(response);
 
-  var challengenum = -1;
-  for (let i = 0; i < leaves.length; i++) {
-    if (Buffer.compare(leaves[i], leaf) === 0) {
-      challengenum = i;
-      break;
-    }
-  }
+  var challengenum = this._findMatchIndex(leaves, leaf);
 
   assert(challengenum !== -1, 'Failed to generate proof');
 

--- a/lib/audit-tools/verification.js
+++ b/lib/audit-tools/verification.js
@@ -29,7 +29,7 @@ Verification.prototype._getChallengeResponse = function(tuple) {
   var data = tuple || this._proof;
 
   if (data.length === 1) {
-    return utils.rmd160sha256(data[0]);
+    return utils.rmd160sha256b(data[0]);
   }
 
   if (Array.isArray(data[0])) {
@@ -49,8 +49,8 @@ Verification.prototype.verify = function(root, totaldepth) {
   function _collapse(proof, leaf, depth) {
     if (depth === 0) {
       assert(proof.length === 1, 'Invalid proof structure');
-      assert(utils.rmd160sha256(proof[0]) === leaf, 'Invalid proof value');
-
+      const proofhash = utils.rmd160sha256b(proof[0]);
+      assert(Buffer.compare(proofhash, leaf) === 0, 'Invalid proof value');
       return leaf;
     }
 
@@ -68,7 +68,7 @@ Verification.prototype.verify = function(root, totaldepth) {
       hashR = proof[1];
     }
 
-    return utils.rmd160sha256(hashL + hashR);
+    return utils.rmd160sha256b(Buffer.concat([hashL, hashR]));
   }
 
   return [

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,6 +43,16 @@ module.exports.sha256 = function(input, encoding) {
 };
 
 /**
+ * Returns the SHA-256 hash of the input
+ * @param {String|Buffer} input - Data to hash
+ * @param {String} encoding - The encoding type of the data
+ * @returns {Buffer}
+ */
+module.exports.sha256b = function(input, encoding) {
+  return crypto.createHash('sha256').update(input, encoding).digest();
+};
+
+/**
  * Returns the SHA-512 hash of the input
  * @param {String|Buffer} input - Data to hash
  * @param {String} encoding - The encoding type of the data
@@ -60,6 +70,16 @@ module.exports.sha512 = function(input, encoding) {
  */
 module.exports.rmd160 = function(input, encoding) {
   return crypto.createHash('rmd160').update(input, encoding).digest('hex');
+};
+
+/**
+ * Returns the RIPEMD-160 hash of the input
+ * @param {String|Buffer} input - Data to hash
+ * @param {String} encoding - The encoding type of the data
+ * @returns {Buffer}
+ */
+module.exports.rmd160b = function(input, encoding) {
+  return crypto.createHash('rmd160').update(input, encoding).digest();
 };
 
 /**
@@ -82,6 +102,16 @@ module.exports.rmd160sha256 = function(input, encoding) {
   return module.exports.rmd160(
     Buffer(module.exports.sha256(input, encoding), 'hex')
   );
+};
+
+/**
+ * Returns the RIPEMD-160 SHA-256 hash of this input
+ * @param {String|Buffer} input - Data to hash
+ * @param {String} encoding - The encoding type of the data
+ * @returns {Buffer}
+ */
+module.exports.rmd160sha256b = function(input, encoding) {
+  return module.exports.rmd160b(module.exports.sha256b(input, encoding))
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "mime": "^1.3.4",
     "mkdirp": "^0.5.1",
     "ms": "^0.7.1",
-    "mtree": "^0.0.1",
+    "mtree": "braydonf/mtree#77a8f27976e72644a13c11cd0ca7dc35616f1c06",
     "nat-upnp": "^1.0.2",
     "node-tar.gz": "^1.0.0",
     "node-uuid": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "mime": "^1.3.4",
     "mkdirp": "^0.5.1",
     "ms": "^0.7.1",
-    "mtree": "braydonf/mtree#77a8f27976e72644a13c11cd0ca7dc35616f1c06",
+    "mtree": "^1.0.0",
     "nat-upnp": "^1.0.2",
     "node-tar.gz": "^1.0.0",
     "node-uuid": "^1.4.7",

--- a/test/audit-tools/audit-stream.unit.js
+++ b/test/audit-tools/audit-stream.unit.js
@@ -25,8 +25,8 @@ describe('AuditStream', function() {
 
     it('should return a random 256 bit challenge', function() {
       var challenge = AuditStream(6)._generateChallenge();
-      expect(challenge).to.have.lengthOf(64);
-      expect(Buffer(challenge, 'hex')).to.have.lengthOf(32);
+      expect(challenge).to.have.lengthOf(32);
+      expect(Buffer.isBuffer(challenge)).to.equal(true);
     });
 
   });

--- a/test/audit-tools/audit-stream.unit.js
+++ b/test/audit-tools/audit-stream.unit.js
@@ -90,7 +90,8 @@ describe('AuditStream', function() {
         var secret = audit.getPrivateRecord();
         expect(secret.root).to.equal(audit._tree.root());
         expect(secret.depth).to.equal(audit._tree.levels());
-        expect(secret.challenges).to.equal(audit._challenges);
+        expect(secret.challenges)
+          .to.eql(audit._challenges.map((i) => i.toString('hex')));
         done();
       });
       audit.write(SHARD);

--- a/test/audit-tools/audit-stream.unit.js
+++ b/test/audit-tools/audit-stream.unit.js
@@ -66,7 +66,7 @@ describe('AuditStream', function() {
       var audit = new AuditStream(12);
       audit.on('finish', function() {
         var secret = audit.getPrivateRecord();
-        expect(secret.root).to.equal(audit._tree.root().toLowerCase());
+        expect(secret.root).to.equal(audit._tree.root());
         expect(secret.depth).to.equal(audit._tree.levels());
         expect(secret.challenges).to.equal(audit._challenges);
         done();
@@ -102,7 +102,7 @@ describe('AuditStream#fromRecords', function() {
       );
       expect(
         audit1.getPrivateRecord().root
-      ).to.equal(
+      ).to.eql(
         audit2.getPrivateRecord().root
       );
       done();

--- a/test/audit-tools/proof-stream.unit.js
+++ b/test/audit-tools/proof-stream.unit.js
@@ -60,7 +60,6 @@ describe('Proof', function() {
       audit.end(SHARD);
       setImmediate(function() {
         var challenge = audit.getPrivateRecord().challenges[1];
-        console.log('challenge', challenge);
         var proof = new ProofStream(audit.getPublicRecord(), challenge);
 
         proof.end(SHARD);

--- a/test/audit-tools/verification.unit.js
+++ b/test/audit-tools/verification.unit.js
@@ -31,7 +31,7 @@ describe('Verification', function() {
       var challengeResp = verification._getChallengeResponse(
         ['beep', ['boop', [['bar'], 'foo']]]
       );
-      expect(challengeResp).to.equal(utils.rmd160sha256('bar'));
+      expect(challengeResp).to.eql(utils.rmd160sha256b('bar'));
     });
 
   });
@@ -50,7 +50,7 @@ describe('Verification', function() {
           var response = proof.getProofResult();
           var verification = new Verification(response);
           var result = verification.verify(secret.root, secret.depth);
-          expect(result[0]).to.equal(result[1]);
+          expect(result[0]).to.eql(result[1]);
           done();
         });
       });

--- a/test/audit-tools/verification.unit.js
+++ b/test/audit-tools/verification.unit.js
@@ -38,7 +38,7 @@ describe('Verification', function() {
 
   describe('#verify', function() {
 
-    it('should verify the proof response', function() {
+    it('should verify the proof response', function(done) {
       var audit = new AuditStream(12);
       audit.end(SHARD);
       setImmediate(function() {
@@ -51,6 +51,7 @@ describe('Verification', function() {
           var verification = new Verification(response);
           var result = verification.verify(secret.root, secret.depth);
           expect(result[0]).to.equal(result[1]);
+          done();
         });
       });
     });

--- a/test/utils.unit.js
+++ b/test/utils.unit.js
@@ -14,6 +14,55 @@ var EventEmitter = require('events').EventEmitter;
 
 describe('utils', function() {
 
+  describe('#sha256', function() {
+    it('it will give digest as buffer', function() {
+      const digest = utils.sha256b('hello, world', 'utf8');
+      expect(Buffer.isBuffer(digest)).to.equal(true);
+      expect(digest.toString('hex'))
+        .to.equal('09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08' +
+                  '360d5b');
+    });
+    it('it will give digest as hex string', function() {
+      const digest = utils.sha256('hello, world', 'utf8');
+      expect(digest).to.be.a('string');
+      expect(digest)
+        .to.equal('09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08' +
+                  '360d5b');
+    });
+  });
+
+  describe('#rmd160', function() {
+    it('it will give digest as buffer', function() {
+      const digest = utils.rmd160b('hello, world', 'utf8');
+      expect(Buffer.isBuffer(digest)).to.equal(true);
+      expect(digest.toString('hex'))
+        .to.equal('a3201f82fca034e46d10cd7b27e174976e241da2');
+    });
+
+    it('it will give digest as hex string', function() {
+      const digest = utils.rmd160('hello, world', 'utf8');
+      expect(digest).to.be.a('string');
+      expect(digest)
+        .to.equal('a3201f82fca034e46d10cd7b27e174976e241da2');
+    });
+  });
+
+  describe('#rmd160sha256b', function() {
+    it('will give digest as buffer', function() {
+      const digest = utils.rmd160sha256b('hello, world', 'utf8');
+      expect(Buffer.isBuffer(digest)).to.equal(true);
+      expect(digest.toString('hex'))
+        .to.equal('cf7c332804ab8ae1df7d7cbe7517b82edb83c680');
+    });
+
+    it('will give digest as hex string', function() {
+      const digest = utils.rmd160sha256('hello, world', 'utf8');
+      expect(digest).to.be.a('string');
+      expect(digest)
+        .to.equal('cf7c332804ab8ae1df7d7cbe7517b82edb83c680');
+    });
+  });
+
   describe('#getContactURL', function() {
 
     it('should return the proper URI format of the contact', function() {


### PR DESCRIPTION
Discovered this issue when comparing challenges and leafs with  [libstorj](https://github.com/Storj/libstorj).

With these changes the audit matches libstorj, and skips unnecessary conversion to base16 encoded strings of shard data. This will improve performance and memory use while hashing.

Additional changes made to mtree at: https://github.com/bookchin/mtree/pull/1/files