### PR TITLE
removing unused transportAdapter from ./lib/network

### DIFF
--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -48,7 +48,6 @@ var utils = require('../utils');
  * @property {TriggerManager} triggerManager
  * @property {BridgeClient} bridgeClient
  * @property {Contact} contact
- * @property {Transport} transportAdapter
  * @property {kad.Router} router - The underlying DHT router
  * @property {DataChannelServer} dataChannelServer
  */

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -54,7 +54,6 @@ var OfferManager = require('../contract/offer-manager');
  * @property {TriggerManager} triggerManager
  * @property {BridgeClient} bridgeClient
  * @property {Contact} contact
- * @property {Transport} transportAdapter
  * @property {kad.Router} router - The underlying DHT router
  * @property {ShardServer} shardServer
  * @property {OfferManager} offerManager

--- a/lib/network/renter.js
+++ b/lib/network/renter.js
@@ -43,7 +43,6 @@ var OfferStream = require('../contract/offer-stream');
  * @property {TriggerManager} triggerManager
  * @property {BridgeClient} bridgeClient
  * @property {Contact} contact
- * @property {Transport} transportAdapter
  * @property {kad.Router} router - The underlying DHT router
  * @property {DataChannelServer} dataChannelServer
  */


### PR DESCRIPTION
```
git clone git@github.com:storj/core
cd core
NODE_ENV=dev npm install
grep -ir 'transportAdapter'
```

This didn't show transportAdapter being used anywhere other than in the jsdocs, believe it is safe to remove.