### PR TITLE
Add an optional different listenPort for local rpc to bind to

### DIFF
--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -38,6 +38,7 @@ var OfferManager = require('../contract/offer-manager');
  * @param {Array} options.seedList - List of seed URIs to join
  * @param {String} options.rpcAddress - Public node IP or hostname
  * @param {Number} options.rpcPort - Listening port for RPC
+ * @param {Number} options.listenPort - Optional different listening port for RPC to bind to
  * @param {Boolean} options.doNotTraverseNat - Skip NAT traversal strategies
  * @param {Number} options.maxTunnels - Max number of tunnels to provide
  * @param {Number} options.maxConnections - Max concurrent connections
@@ -435,7 +436,8 @@ Network.prototype._initNetworkInterface = function() {
     tunnelGatewayRange: this._options.tunnelGatewayRange,
     doNotTraverseNat: this._options.doNotTraverseNat,
     storageManager: this.storageManager,
-    bridgeClient: this._bridgeClient
+    bridgeClient: this._bridgeClient,
+    listenPort: this._options.listenPort
   });
   this.router = new kad.Router({
     transport: this.transport,

--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -26,6 +26,7 @@ const ShardServer = require('./shard-server');
  * @param {Object}  options.tunnelGatewayRange
  * @param {Number}  options.tunnelGatewayRange.min - Min port for gateway bind
  * @param {Number}  options.tunnelGatewayRange.max - Max port for gateway bind
+ * @param {Number}  options.listenPort - Different port for the server to listen on (optional)
  * @param {StorageManager} options.storageManager
  * @param {BridgeClient} options.bridgeClient
  */
@@ -162,7 +163,9 @@ Transport.prototype._bindServer = function(callback) {
     self.shardServer.routeRetrieval.bind(self.shardServer)
   );
 
-  self._server.listen(self._contact.port, callback);
+  const port = self._opts.listenPort ?
+    self._opts.listenPort : self._contact.port;
+  self._server.listen(port, callback);
 };
 
 /**

--- a/test/bridge-client/upload-state.unit.js
+++ b/test/bridge-client/upload-state.unit.js
@@ -10,7 +10,7 @@ describe('UploadState', function() {
   describe('@constructor', function() {
 
     it('should create an instance without the new keyword', function() {
-      expect(UploadState()).to.be.instanceOf(UploadState);
+      expect(UploadState({worker: {}})).to.be.instanceOf(UploadState);
     });
 
   });
@@ -27,7 +27,7 @@ describe('UploadState', function() {
           existsSync: sinon.stub().returns(true)
         }
       });
-      var uploadState = new StubUploadState();
+      var uploadState = new StubUploadState({worker: {}});
       uploadState.cleanQueue.push({
         store: {
           exists: function(key, cb) {
@@ -44,7 +44,7 @@ describe('UploadState', function() {
     it('should close uploaders', function(done) {
       var StubUploadState = proxyquire('../../lib/bridge-client/upload-state', {
       });
-      var uploadState = new StubUploadState();
+      var uploadState = new StubUploadState({worker: {}});
       uploadState.uploaders = [{
         end: function() {
           done();
@@ -56,7 +56,7 @@ describe('UploadState', function() {
     it('should handle non-existant keys', function(done) {
       var StubUploadState = proxyquire('../../lib/bridge-client/upload-state', {
       });
-      var uploadState = new StubUploadState();
+      var uploadState = new StubUploadState({worker: {}});
       uploadState.cleanQueue.push({
         store: {
           exists: function(key, cb) {

--- a/test/network/transport.unit.js
+++ b/test/network/transport.unit.js
@@ -96,6 +96,21 @@ describe('Network/Transport', function() {
       });
     });
 
+    it('should use listenPort if supplied', function(done) {
+      var transport = new Transport(Contact({
+        address: '127.0.0.1',
+        port: 0,
+        nodeID: KeyPair().getNodeID()
+      }), {
+        storageManager: StorageManager(RamAdapter()),
+        listenPort: 10001
+      });
+      transport.on('ready', function() {
+        expect(transport._server.address().port).to.equal(10001);
+        done();
+      });
+    });
+
   });
 
   describe('#_checkIfReachable', function() {


### PR DESCRIPTION
Allow the use of an optional different listening port to be supplied for the rpc server to bind to.

This is useful when starting storjshare with the `rpcPort: 80` and `listenPort: 10001` and a nginx reverse proxy configured to proxy from 80 -> 10001.
In such a case storjshare can still run as non-root and one is able to neatly manage all dns and address configuration via nginx.