### PR TITLE
Core updates for Ease-of-Use improvements

### DIFF
--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -149,7 +149,7 @@ FarmerInterface.Negotiator = function(contract, callback) {
 FarmerInterface.DEFAULTS = {
   renterWhitelist: fs.readFileSync(
     path.join(__dirname, '../../TRUSTED_KEYS')
-  ).toString().replace('\r','').split('\n').filter((k) => !!k),
+  ).toString().split('\n').filter((k) => !!k),
   paymentAddress: '',
   opcodeSubscriptions: ['0f01020202', '0f02020202', '0f03020202'],
   contractNegotiator: FarmerInterface.Negotiator,

--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -347,9 +347,8 @@ FarmerInterface.prototype._handleOfferRes = function(res, contract, renter) {
     self.storageManager.save(item, utils.noop);
     self._logger.info('Offer accepted');
     if (self._contractCount < Number.MAX_SAFE_INTEGER) { 
-      self._contractCount++; 
-    } 
-    else { 
+      self._contractCount++;
+    } else { 
       self._contractCount = 0; 
     } 
   });

--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -149,7 +149,7 @@ FarmerInterface.Negotiator = function(contract, callback) {
 FarmerInterface.DEFAULTS = {
   renterWhitelist: fs.readFileSync(
     path.join(__dirname, '../../TRUSTED_KEYS')
-  ).toString().split('\n').filter((k) => !!k),
+  ).toString().replace('\r','').split('\n').filter((k) => !!k),
   paymentAddress: '',
   opcodeSubscriptions: ['0f01020202', '0f02020202', '0f03020202'],
   contractNegotiator: FarmerInterface.Negotiator,

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -682,7 +682,7 @@ Network.prototype._listenForTunnelers = function() {
 Network.prototype._setupTunnelClient = function(callback) {
   var self = this;
 
-  if (this.transport._isPublic || this.transport._doNotTraverseNat) {
+  if (this.transport._isPublic) {
     return callback(null);
   }
 

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -682,7 +682,7 @@ Network.prototype._listenForTunnelers = function() {
 Network.prototype._setupTunnelClient = function(callback) {
   var self = this;
 
-  if (this.transport._isPublic) {
+  if (this.transport._isPublic || this.transport._doNotTraverseNat) {
     return callback(null);
   }
 
@@ -863,6 +863,7 @@ Network.prototype._establishTunnel = function(tunnels, callback) {
       self._logger.info('tunnel successfully established');
 
       tunnelWasOpened = true;
+      self._tunneled = true;
       self.contact.address = remoteAddress;
       self.contact.port = remotePort;
 

--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -88,7 +88,8 @@ Transport.prototype._open = function(callback) {
   });
 
   if (self._doNotTraverseNat) {
-    self._isPublic = ip.isPublic(self._contact.address);
+    self._isPublic = true; // used to determine tunneling
+    self._publicIp = ip.isPublic(self._contact.address); // used for UI status
     self._checkIfReachable(function(reachable) {
       self._portOpen = reachable;
     });
@@ -97,7 +98,7 @@ Transport.prototype._open = function(callback) {
     /* istanbul ignore next */
     self._log.warn(
       'your address is %s and traversal strategies are disabled',
-      self._isPublic ? 'public' : 'private'
+      self._publicIp ? 'public' : 'private'
     );
 
     return self._bindServer(callback);

--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -88,12 +88,16 @@ Transport.prototype._open = function(callback) {
   });
 
   if (self._doNotTraverseNat) {
-    self._isPublic = true;
+    self._isPublic = ip.isPublic(self._contact.address);
+    self._checkIfReachable(function(reachable) {
+      self._portOpen = reachable;
+    })
+    self._requiresTraversal = false;
 
     /* istanbul ignore next */
     self._log.warn(
       'your address is %s and traversal strategies are disabled',
-      ip.isPublic(self._contact.address) ? 'public' : 'private'
+      self._isPublic ? 'public' : 'private'
     );
 
     return self._bindServer(callback);
@@ -106,7 +110,7 @@ Transport.prototype._open = function(callback) {
       'you are not publicly reachable, trying traversal strategies...'
     );
     self._forwardPort(function(err, wanip, port) {
-      self._isPublic = !err;
+      self._isPublic = self._portOpen = !err;
 
       if (self._isPublic) {
         self._contact.port = port || self._contact.port;
@@ -121,6 +125,7 @@ Transport.prototype._open = function(callback) {
   self._bindServer(function() {
     self._checkIfReachable(function(isReachable) {
       if (isReachable) {
+        self._isPublic = self._portOpen = true;
         return callback(null);
       }
 

--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -91,7 +91,7 @@ Transport.prototype._open = function(callback) {
     self._isPublic = ip.isPublic(self._contact.address);
     self._checkIfReachable(function(reachable) {
       self._portOpen = reachable;
-    })
+    });
     self._requiresTraversal = false;
 
     /* istanbul ignore next */

--- a/test/network/farmer.unit.js
+++ b/test/network/farmer.unit.js
@@ -592,6 +592,33 @@ describe('FarmerInterface', function() {
       });
     });
 
+    it('should reset contract count to 0 to prevent overflow', function(done) {
+      var farmer = new FarmerInterface({
+        keyPair: KeyPair(),
+        rpcPort: 0,
+        tunnelServerPort: 0,
+        doNotTraverseNat: true,
+        logger: kad.Logger(0),
+        storageManager: new StorageManager(new RAMStorageAdapter())
+      });
+      CLEANUP.push(farmer);
+      var _load = sinon.stub(farmer.storageManager, 'load').callsArgWith(1, {});
+      var _save = sinon.stub(farmer.storageManager, 'save');
+      var _verify = sinon.stub(Contract.prototype, 'verify').returns(true);
+      farmer._contractCount = Number.MAX_SAFE_INTEGER;
+      farmer._handleOfferRes({
+        result: {
+          contract: Contract({}).toObject()
+        }
+      }, new Contract(), {nodeID: 'nodeid'});
+      setImmediate(function() {
+        _load.restore();
+        _save.restore();
+        _verify.restore();
+        expect(farmer._contractCount).to.equal(0);
+        done();
+      });
+    });
   });
 
   describe('#_listenForContracts', function() {


### PR DESCRIPTION
This is to implement https://github.com/Storj/storjshare-gui/issues/513

- [x] Make port status accessible
- [x] Make NTP delta accessible and re-check it periodically
- [x] Make contract count available

When establishing farmer ensure flags are set for isPublic and requiresTraversal. Additionally, call checkIfReachable even if not traversing NAT to see if port is open. We can then allow CLI and GUI to determine the port and how the farmer is connected to Storj network

Example of CLI using this code:

![storj-cli](https://user-images.githubusercontent.com/1991399/27239008-31cc685c-529d-11e7-9c44-48f15a42ad1a.png)
