### PR TITLE
Add maxShardSize to not respond to contracts with too large shard sizes

### DIFF
--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -41,6 +41,7 @@ var utils = require('../utils');
  * @param {Object} [options.joinRetry]
  * @param {Number} [options.joinRetry.times] - Times to retry joining net
  * @param {Number} [options.joinRetry.interval] - MS to wait before retrying
+ * @param {Number} [options.maxShardSize] - Max number of bytes to allow as contract shard size
  * @emits Network#ready
  * @property {KeyPair} keyPair
  * @property {StorageManager} storageManager
@@ -65,6 +66,7 @@ function FarmerInterface(options) {
   this._renterWhitelist = Array.isArray(options.renterWhitelist) ?
                           options.renterWhitelist :
                           null;
+  this._maxShardSize = options.maxShardSize;
 
   Network.call(this, options);
 }
@@ -80,8 +82,14 @@ inherits(FarmerInterface, Network);
  * @returns {Boolean}
  */
 
+// eslint-disable-next-line max-statements
 FarmerInterface.Negotiator = function(contract, callback) {
+  /* eslint complexity: [2, 7] */
   var self = this;
+
+  if (this._maxShardSize && this._maxShardSize < contract.get('data_size')) {
+    return callback(false);
+  }
 
   if (this._renterWhitelist) {
     var allowed =  {

--- a/test/network/farmer.unit.js
+++ b/test/network/farmer.unit.js
@@ -193,6 +193,32 @@ describe('FarmerInterface', function() {
 
   });
 
+  describe('#_negotiator', function() {
+
+    it('should return false with too large shardSize', function(done) {
+      var farmer = new FarmerInterface({
+        keyPair: KeyPair(),
+        rpcPort: 0,
+        tunnelServerPort: 0,
+        doNotTraverseNat: true,
+        logger: kad.Logger(0),
+        maxShardSize: 99 * 1024 * 1024,
+        storageManager: new StorageManager(new RAMStorageAdapter()),
+        renterWhitelist: null
+      });
+      CLEANUP.push(farmer);
+      farmer._negotiator(Contract({
+        data_hash: utils.rmd160(' some data'),
+        renter_id: utils.rmd160('nodeid'),
+        data_size: 100 * 1024 * 1024
+      }), function(result) {
+        expect(result).to.equal(false);
+        done();
+      });
+    });
+
+  });
+
   describe('#_negotiateContract', function() {
 
     it('should ensure renter id is present and warn if not', function(done) {

--- a/test/storage/migration.unit.js
+++ b/test/storage/migration.unit.js
@@ -54,6 +54,7 @@ describe('StorageMigration', function() {
     var source, target;
 
     before(function(done) {
+      this.timeout(4000);
       source = new EmbeddedStorageAdapter(_p('t5'));
       target = new EmbeddedStorageAdapter(_p('t6'));
 


### PR DESCRIPTION
This PR will add the functionality to ignore contracts (not respond with offer) if the shard size is higher than a predefined value (`maxShardSize`). This allows a more fine grained control over shard sizes to accept than opcodes offer. This is done without altering the protocol and increasing the amount of opcodes/values.