### PR TITLE
log shard size and available bucket size

### DIFF
--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -298,6 +298,12 @@ FarmerInterface.prototype._shouldSendOffer = function(contract, callback) {
         var estimatedMaxBucketSize = Math.floor(maxCapacity / kfs.constants.B);
         var freeSpace = estimatedMaxBucketSize - usedSpace;
         var enoughFreeSpace = contract.get('data_size') <= freeSpace;
+        self._logger.debug(
+          'max KFS bucket size %s, used %s, free %s, shard size %s',
+          estimatedMaxBucketSize,
+          usedSpace,
+          freeSpace,
+          contract.get('data_size'));
         self._logger.debug('we have enough free space: %s', enoughFreeSpace);
 
         callback(shouldNegotiate && enoughFreeSpace);

--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -288,14 +288,16 @@ FarmerInterface.prototype._shouldSendOffer = function(contract, callback) {
     self._logger.debug('negotiator returned: %s', shouldNegotiate);
     self.storageManager._storage.size(
       contract.get('data_hash'),
-      function(err, usedSpace) {
+      function(err, usedSpace, contractDBSize) {
         if (err) {
           self._logger.error('Could not get usedSpace: %s',err.message);
           return callback(false);
         }
 
         var maxCapacity = self.storageManager._options.maxCapacity;
-        var estimatedMaxBucketSize = Math.floor(maxCapacity / kfs.constants.B);
+        var estimatedMaxBucketSize = Math.floor(
+          (maxCapacity - contractDBSize) / kfs.constants.B
+        );
         var freeSpace = estimatedMaxBucketSize - usedSpace;
         var enoughFreeSpace = contract.get('data_size') <= freeSpace;
         self._logger.debug(

--- a/lib/network/monitor.js
+++ b/lib/network/monitor.js
@@ -161,7 +161,7 @@ Monitor.getConnectedPeers = function(source, callback) {
 Monitor.getDiskUtilization = function(source, callback) {
   var stats = { free: source.storageManager._options.maxCapacity };
 
-  source.storageManager._storage.size(function(err, bytes) {
+  source.storageManager._storage.size(function(err, shardsize, contractsize) {
     if (err) {
       return callback(null, {
         disk: merge(stats, { used: 0, free: stats.free })
@@ -169,7 +169,10 @@ Monitor.getDiskUtilization = function(source, callback) {
     }
 
     callback(null, {
-      disk: merge(stats, { used: bytes, free: stats.free - bytes })
+      disk: merge(stats, {
+        used: shardsize + contractsize,
+        free: stats.free - (shardsize + contractsize) 
+      })
     });
   });
 };

--- a/lib/storage/adapters/embedded.js
+++ b/lib/storage/adapters/embedded.js
@@ -213,7 +213,7 @@ EmbeddedStorageAdapter.prototype._size = function(key, callback) {
           sBucketStats: { size: 0 }
         }).sBucketStats.size;
 
-        callback(null, kfsUsedSpace + contractDbSize);
+        callback(null, kfsUsedSpace, contractDbSize);
       }
 
       /* istanbul ignore if */

--- a/test/network/farmer.unit.js
+++ b/test/network/farmer.unit.js
@@ -131,7 +131,7 @@ describe('FarmerInterface', function() {
       var _size = sinon.stub(
         farmer.storageManager._storage,
         'size'
-      ).callsArgWith(1, null, 1000);
+      ).callsArgWith(1, null, 500, 500);
       farmer.storageManager._options.maxCapacity = 2000;
       var _addTo = sinon.stub(farmer, '_addContractToPendingList');
       //execute

--- a/test/network/monitor.unit.js
+++ b/test/network/monitor.unit.js
@@ -215,11 +215,11 @@ describe('Monitor#getDiskUtilization', function() {
     Monitor.getDiskUtilization({
       storageManager: {
         _options: { maxCapacity: 2048 },
-        _storage: { size: sinon.stub().callsArgWith(0, null, 1024) }
+        _storage: { size: sinon.stub().callsArgWith(0, null, 1024, 512) }
       }
     }, function(err, stats) {
-      expect(stats.disk.used).to.equal(1024);
-      expect(stats.disk.free).to.equal(1024);
+      expect(stats.disk.used).to.equal(1536);
+      expect(stats.disk.free).to.equal(512);
       done();
     });
   });

--- a/test/storage/adapters/embedded.unit.js
+++ b/test/storage/adapters/embedded.unit.js
@@ -265,10 +265,17 @@ describe('EmbeddedStorageAdapter', function() {
         null,
         7 * 1024
       );
+      var _stat = sinon.stub(store._fs, 'stat').callsArgWith(
+        0,
+        null,
+        [{sBucketStats: {size: 2 * 1024}}, {sBucketStats: {size: 3 * 1024}}]
+      );
       store._isUsingDefaultBackend = true;
-      store._size(function(err, size) {
+      store._size(function(err, shardsize, contractsize) {
         _approx.restore();
-        expect(size).to.equal(7 * 1024);
+        _stat.restore();
+        expect(shardsize).to.equal(5 * 1024);
+        expect(contractsize).to.equal(7 * 1024);
         done();
       });
     });


### PR DESCRIPTION
* Closes https://github.com/Storj/storjshare-daemon/issues/207
* Closes https://github.com/Storj/core/issues/708

```
{"level":"debug","message":"max KFS bucket size 34359738368, used 8608703, free 34351129665, shard size 537264","timestamp":"2017-07-22T21:56:34.649Z"}
{"level":"debug","message":"max KFS bucket size 34359738368, used 8608703, free 34351129665, shard size 19456","timestamp":"2017-07-22T21:57:54.332Z"}
{"level":"debug","message":"max KFS bucket size 34359738368, used 8608703, free 34351129665, shard size 34304","timestamp":"2017-07-22T21:58:51.691Z"}
```