### PR TITLE
remove depricated toNumberBytes

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -231,40 +231,6 @@ module.exports.validateLogger = function(logger) {
 };
 
 /**
- * Returns number of bytes from human readable size and unit strings
- * @param {String|Number} size - The size measurement
- * @param {String} unit - The unit of measure (MB|MiB|GB|GiB|TB|TiB)
- * @returns {Number}
- */
-module.exports.toNumberBytes = function(size, unit) {
-  /* eslint complexity: [2, 7] */
-  switch (unit.toUpperCase()) {
-    case 'MB':
-      size = Number(size) * Math.pow(1000, 2);
-      break;
-    case 'GB':
-      size = Number(size) * Math.pow(1000, 3);
-      break;
-    case 'TB':
-      size = Number(size) * Math.pow(1000, 4);
-      break;
-    case 'MIB':
-      size = Number(size) * Math.pow(1024, 2);
-      break;
-    case 'GIB':
-      size = Number(size) * Math.pow(1024, 3);
-      break;
-    case 'TIB':
-      size = Number(size) * Math.pow(1024, 4);
-      break;
-    default:
-      throw new Error('Unit must be one of TB, TiB, GB, GiB, MB or MiB');
-  }
-
-  return Number(size.toFixed());
-};
-
-/**
  * Encrypts the given data with the supplied password and base58 encodes it
  * @param {String} password - The passphrase to use for encryption
  * @param {String} data - The string to encrypt

--- a/test/utils.unit.js
+++ b/test/utils.unit.js
@@ -228,40 +228,6 @@ describe('utils', function() {
 
   });
 
-  describe('#toNumberBytes', function() {
-
-    it('should convert from mebibytes', function() {
-      expect(utils.toNumberBytes('250', 'MiB')).to.equal(262144000);
-    });
-
-    it('should convert from gibibytes', function() {
-      expect(utils.toNumberBytes('500', 'GiB')).to.equal(536870912000);
-    });
-
-    it('should convert from tebibytes', function() {
-      expect(utils.toNumberBytes('2', 'TiB')).to.equal(2199023255552);
-    });
-
-    it('should convert from megabytes', function() {
-      expect(utils.toNumberBytes('250', 'MB')).to.equal(250000000);
-    });
-
-    it('should convert from gigabytes', function() {
-      expect(utils.toNumberBytes('500', 'GB')).to.equal(500000000000);
-    });
-
-    it('should convert from terabytes', function() {
-      expect(utils.toNumberBytes('2', 'TB')).to.equal(2000000000000);
-    });
-
-    it('should throw if bad unit', function() {
-      expect(function() {
-        utils.toNumberBytes('1000', 'KB');
-      }).to.throw(Error, 'Unit must be one of TB, TiB, GB, GiB, MB or MiB');
-    });
-
-  });
-
   describe('#simpleEncrypt + #simpleDecrypt', function() {
 
     it('should successfully encrypt and decrypt the data', function() {


### PR DESCRIPTION
We are now using this: https://github.com/Storj/storjshare-daemon/blob/749905706f245bbcee38573e5d7d7749bcc42fb1/lib/utils.js#L93

The old function is depricated and can be removed.