### PR TITLE
Persistent tokens with TTL for SIP6

### DIFF
--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const async = require('async');
+const assert = require('assert');
 const secp256k1 = require('secp256k1');
 const https = require('https');
 const http = require('http');
@@ -73,6 +74,8 @@ function FarmerInterface(options) {
   this._offerBackoffLimit = options.offerBackoffLimit;
 
   this._maxShardSize = options.maxShardSize;
+
+  assert(options.storagePath, 'storagePath is expected option');
 
   Network.call(this, options);
 

--- a/lib/network/farmer.js
+++ b/lib/network/farmer.js
@@ -826,7 +826,6 @@ FarmerInterface.prototype.handleAlloc = function(params, callback) {
         return self._logger.error(err.message);
       }
 
-      // TODO these tokens will need to be persistent
       self.transport.shardServer.accept(
         token,
         contractObj.get('data_hash'),

--- a/lib/network/index.js
+++ b/lib/network/index.js
@@ -368,27 +368,35 @@ Network.prototype._enterOverlay = function(onConnected) {
 Network.prototype.leave = function(callback) {
   var self = this;
 
-  if (typeof callback === 'function') {
-    this.once('error', callback);
-    this.once('disconnected', function() {
-      this.removeListener('error', callback);
-      callback(null);
-    });
-  }
-
-  this.storageManager.close(function(err) {
-    if (err) {
-      return self.emit('error', err);
-    }
-
-    self.node.disconnect(function(err) {
-      if (err) {
-        return self.emit('error', err);
+  async.series([
+    (next) => {
+      if (this.transport && this.transport.shardServer) {
+        this.transport.shardServer.close(next);
+      } else {
+        next();
       }
+    },
+    (next) => {
+      this.storageManager.close(function(err) {
+        if (err) {
+          return next(err);
+        }
 
-      self.emit('disconnected');
-    });
-  });
+        if (!self.node) {
+          return next();
+        }
+
+        self.node.disconnect(function(err) {
+          if (err) {
+            return next(err);
+          }
+
+          self.emit('disconnected');
+          next();
+        });
+      });
+    }
+  ], callback);
 };
 
 /**
@@ -466,6 +474,7 @@ Network.prototype._initNetworkInterface = function() {
   });
   this.transport = new Transport(this.contact, {
     logger: this._logger,
+    storagePath: this._options.storagePath,
     maxTunnels: this._options.maxTunnels,
     maxConnections: this._options.maxConnections,
     tunnelGatewayRange: this._options.tunnelGatewayRange,

--- a/lib/network/renter.js
+++ b/lib/network/renter.js
@@ -41,7 +41,6 @@ var OfferStream = require('../contract/offer-stream');
  * @property {StorageManager} storageManager
  * @property {kad.Node} node - The underlying DHT node
  * @property {TriggerManager} triggerManager
- * @property {BridgeClient} bridgeClient
  * @property {Contact} contact
  * @property {Transport} transportAdapter
  * @property {kad.Router} router - The underlying DHT router

--- a/lib/network/shard-server.js
+++ b/lib/network/shard-server.js
@@ -8,7 +8,6 @@ const levelup = require('levelup');
 const ExchangeReport = require('../bridge-client/exchange-report');
 const StorageManager = require('../storage/manager');
 const Contact = require('./contact');
-const constants = require('../constants');
 const inherits = require('util').inherits;
 const utils = require('../utils');
 
@@ -141,7 +140,7 @@ ShardServer.prototype.reject = function(token, callback) {
 
     try {
       parsed = JSON.parse(data);
-    } catch(err) {
+    } catch (err) {
       return callback(new Error('Unable to parse token data'));
     }
 
@@ -174,8 +173,6 @@ ShardServer.prototype._checkOptions = function(options) {
  * @param {String} hash
  */
 ShardServer.prototype.isAuthorized = function(token, hash, callback) {
-  var self = this;
-
   if (!token) {
     return callback(new Error('You did not supply a token'));
   }
@@ -195,7 +192,7 @@ ShardServer.prototype.isAuthorized = function(token, hash, callback) {
 
     try {
       parsed = JSON.parse(data);
-    } catch(e) {
+    } catch (e) {
       return callback(new Error('Unable to parse token data'));
     }
 
@@ -423,11 +420,18 @@ ShardServer.prototype.routeRetrieval = function(req, res) {
 };
 
 /**
+ * Close token database
+ * @param {Function} callback
+ */
+ShardServer.prototype.close = function(callback) {
+  this._db.close(callback);
+}
+
+/**
  * Enumerates the authorized list and rejects expired
  * @private
  */
 ShardServer.prototype._reapDeadTokens = function() {
-  let now = Date.now();
   let ops = [];
 
   let stream = this._db.createReadStream({

--- a/lib/network/shard-server.js
+++ b/lib/network/shard-server.js
@@ -1,14 +1,15 @@
 'use strict';
 
-var assert = require('assert');
-var StorageManager = require('../storage/manager');
-var events = require('events');
-var inherits = require('util').inherits;
-var crypto = require('crypto');
-var utils = require('../utils');
-var constants = require('../constants');
-var ExchangeReport = require('../bridge-client/exchange-report');
-
+const assert = require('assert');
+const crypto = require('crypto');
+const events = require('events');
+const path = require('path');
+const levelup = require('levelup');
+const ExchangeReport = require('../bridge-client/exchange-report');
+const StorageManager = require('../storage/manager');
+const constants = require('../constants');
+const inherits = require('util').inherits;
+const utils = require('../utils');
 
 /**
  * Creates a shard server for sending and receiving consigned file shards
@@ -39,8 +40,8 @@ function ShardServer(options) {
   this._log = options.logger;
   this._ttl = options.tokenTtl || ShardServer.TOKEN_EXPIRE;
 
-  this._path = options.storagePath;
-  this._db = levelup(path.join(this._path, 'tokens.db'), {
+  this._dbPath = path.join(options.storagePath, 'tokens.db');
+  this._db = levelup(this._dbPath, {
     maxOpenFiles: ShardServer.MAX_OPEN_FILES
   });
 
@@ -81,6 +82,7 @@ inherits(ShardServer, events.EventEmitter);
 ShardServer.prototype.accept = function(token, filehash, contact, callback) {
   assert(typeof token === 'string', 'Invalid token supplied');
   assert(typeof filehash === 'string', 'Invalid filehash supplied');
+  assert(contact, 'Contact parameter is expected');
 
   if (!callback) {
     callback = (err) => {
@@ -93,7 +95,7 @@ ShardServer.prototype.accept = function(token, filehash, contact, callback) {
   let expires = Date.now() + this._ttl;
   let data = JSON.stringify({
     hash: filehash,
-    contact: contact.toObject(),
+    contact: contact,
     expires: expires
   });
 
@@ -104,7 +106,7 @@ ShardServer.prototype.accept = function(token, filehash, contact, callback) {
     { type: 'put', key: 'EX' + expires, value: token }
   ]
 
-  this._db.batch(opts, callback);
+  this._db.batch(ops, callback);
 };
 
 /**
@@ -167,7 +169,7 @@ ShardServer.prototype.isAuthorized = function(token, hash, callback) {
   var self = this;
 
   if (!token) {
-    return callback(new Error('You did not supply a token');
+    return callback(new Error('You did not supply a token'));
   }
 
   if (!hash) {
@@ -250,7 +252,7 @@ ShardServer.prototype.routeConsignment = function(req, res) {
       res.send(401, { result: err.message });
     }
 
-    let report: new ExchangeReport({
+    let report = new ExchangeReport({
       reporterId: this._nodeID,
       farmerId: this._nodeID
     })
@@ -357,7 +359,7 @@ ShardServer.prototype.routeRetrieval = function(req, res) {
       return res.send(401, { result: err.message });
     }
 
-    let report: new ExchangeReport({
+    let report = new ExchangeReport({
       reporterId: this._nodeID,
       farmerId: this._nodeID
     })
@@ -437,7 +439,7 @@ ShardServer.prototype._reapDeadTokens = function() {
     ops.push({ type: 'del', key: 'EX' + parsed.expire });
   })
 
-  stream.on('error', (err) {
+  stream.on('error', (err) => {
     this._log.error(err);
   });
 

--- a/lib/network/shard-server.js
+++ b/lib/network/shard-server.js
@@ -46,7 +46,8 @@ function ShardServer(options) {
     maxOpenFiles: ShardServer.MAX_OPEN_FILES
   });
 
-  setInterval(this._reapDeadTokens.bind(this), ShardServer.REAPER_INTERVAL);
+  this._reapDeadTokensInterval = setInterval(
+    this._reapDeadTokens.bind(this), ShardServer.REAPER_INTERVAL);
 }
 
 ShardServer.TOKEN_EXPIRE = 2592000000;
@@ -104,11 +105,17 @@ ShardServer.prototype.accept = function(token, filehash, contact, callback) {
   // and another to search for tokens for when they expire
   var ops = [
     { type: 'put', key: 'TK' + token, value: data },
-    { type: 'put', key: 'EX' + expires, value: token }
+    { type: 'put', key: this._encodeExpiresKey(expires), value: token }
   ]
 
   this._db.batch(ops, callback);
 };
+
+ShardServer.prototype._encodeExpiresKey = function(expires) {
+  let e = Buffer.alloc(8, 0);
+  e.writeDoubleBE(expires);
+  return 'EX' + e.toString('hex');
+}
 
 /**
  * Stop accepting data for the given token
@@ -140,7 +147,7 @@ ShardServer.prototype.reject = function(token, callback) {
 
     let ops = [
       { type: 'del', key: 'TK' + token },
-      { type: 'del', key: 'EX' + parsed.expires }
+      { type: 'del', key: this._encodeExpiresKey(parsed.expires) }
     ];
 
     this._db.batch(ops, callback);
@@ -424,21 +431,13 @@ ShardServer.prototype._reapDeadTokens = function() {
   let ops = [];
 
   let stream = this._db.createReadStream({
-    lte: 'EX' + Date.now(),
-    gte: 'EX' + 0
+    lte: this._encodeExpiresKey(Date.now()),
+    gte: this._encodeExpiresKey(0)
   });
 
   stream.on('data', (data) => {
-    let parsed = {};
-    try {
-      parsed = JSON.parse(data);
-    } catch(err) {
-      this._log.error('Unable to parse data in token reaper');
-      return;
-    }
-
-    ops.push({ type: 'del', key: 'TK' + parsed.token });
-    ops.push({ type: 'del', key: 'EX' + parsed.expires });
+    ops.push({ type: 'del', key: 'TK' + data.value });
+    ops.push({ type: 'del', key: data.key });
   })
 
   stream.on('error', (err) => {
@@ -450,6 +449,7 @@ ShardServer.prototype._reapDeadTokens = function() {
       if (err) {
         this._log.error(err);
       }
+      this.emit('reapedTokens', ops.length / 2);
     });
   });
 };

--- a/lib/network/shard-server.js
+++ b/lib/network/shard-server.js
@@ -9,12 +9,14 @@ var utils = require('../utils');
 var constants = require('../constants');
 var ExchangeReport = require('../bridge-client/exchange-report');
 
+
 /**
  * Creates a shard server for sending and receiving consigned file shards
  * @constructor
  * @license AGPL-3.0
  * @param {Object} options
  * @param {String} options.nodeID - The farmer nodeID
+ * @param {String} options.storagePath - Path to store tokens db
  * @param {StorageManager} options.storageManager - Storage manager backend
  * @param {kad.Logger} options.logger - Logger to use from {@link Network}
  * @param {Number} [options.tokenTtl=1800000] - Close after idle
@@ -35,11 +37,19 @@ function ShardServer(options) {
 
   this._manager = options.storageManager;
   this._log = options.logger;
-  this._ttl = options.tokenTtl || constants.TOKEN_EXPIRE;
-  this._allowed = {};
+  this._ttl = options.tokenTtl || ShardServer.TOKEN_EXPIRE;
 
-  setInterval(this._reapDeadTokens.bind(this), this._ttl);
+  this._path = options.storagePath;
+  this._db = levelup(path.join(this._path, 'tokens.db'), {
+    maxOpenFiles: ShardServer.MAX_OPEN_FILES
+  });
+
+  setInterval(this._reapDeadTokens.bind(this), ShardServer.REAPER_INTERVAL);
 }
+
+ShardServer.TOKEN_EXPIRE = 2592000000;
+ShardServer.MAX_OPEN_FILES = 10;
+ShardServer.REAPER_INTERVAL = 60000;
 
 /**
  * Triggered when a shard has finished uploading to this instance
@@ -66,29 +76,66 @@ inherits(ShardServer, events.EventEmitter);
  * @param {String} token - The authorization token created for transfer
  * @param {String} filehash - The shard hash to allow for the token
  * @param {Contact} contact - contact that negotiated the token
+ * @param {Function} callback
  */
-ShardServer.prototype.accept = function(token, filehash, contact) {
+ShardServer.prototype.accept = function(token, filehash, contact, callback) {
   assert(typeof token === 'string', 'Invalid token supplied');
   assert(typeof filehash === 'string', 'Invalid filehash supplied');
 
-  this._allowed[token] = {
+  if (!callback) {
+    callback = (err) => {
+      if (err) {
+        this._log.error(err);
+      }
+    }
+  }
+
+  let expires = Date.now() + this._ttl;
+  let data = JSON.stringify({
     hash: filehash,
-    contact: contact,
-    expires: Date.now() + this._ttl,
-    report: new ExchangeReport({
-      reporterId: this._nodeID,
-      farmerId: this._nodeID
-    })
-  };
+    contact: contact.toObject(),
+    expires: expires
+  });
+
+  // Atomically create two records, one with the data
+  // and another to search for tokens for when they expire
+  var ops = [
+    { type: 'put', key: 'TK' + token, value: data },
+    { type: 'put', key: 'EX' + expires, value: token }
+  ]
+
+  this._db.batch(opts, callback);
 };
 
 /**
  * Stop accepting data for the given token
  * @param {String} token - The authorization token created for transfer
  */
-ShardServer.prototype.reject = function(token) {
+ShardServer.prototype.reject = function(token, callback) {
   assert(typeof token === 'string', 'Invalid token supplied');
-  delete this._allowed[token];
+
+  if (!callback) {
+    callback = (err) => {
+      if (err) {
+        this._log.error(err);
+      }
+    }
+  }
+
+  this._db.get(token, (err, data) => {
+    if (err) {
+      return callback(err);
+    }
+
+    // TODO get data as json?
+
+    let ops = [
+      { type: 'del', key: 'TK' + data.token },
+      { type: 'del', key: 'EX' + data.expire }
+    ];
+
+    this._db.del(token, callback);
+  });
 };
 
 /**
@@ -110,20 +157,44 @@ ShardServer.prototype._checkOptions = function(options) {
  * @param {String} token
  * @param {String} hash
  */
-ShardServer.prototype.isAuthorized = function(token, hash) {
+ShardServer.prototype.isAuthorized = function(token, hash, callback) {
   var self = this;
 
-  try {
-    assert.ok(token, 'You did not supply a token');
-    assert.ok(self._allowed[token], 'The supplied token is not accepted');
-    assert.ok(hash, 'You did not supply the data hash');
-    assert(self._allowed[token].expires > Date.now(), 'Token has expired');
-    assert(self._allowed[token].hash === hash, 'Token not valid for hash');
-  } catch (err) {
-    return [false, err];
+  if (!token) {
+    return callback(new Error('You did not supply a token');
   }
 
-  return [true, null];
+  if (!hash) {
+    return callback(new Error('You did not supply the data hash'));
+  }
+
+  this._db.get('TK' + token, (err, data) => {
+    if (err && err.notFound) {
+      return callback(new Error('The supplied token is not accepted'));
+    } else if (err) {
+      return callback(err);
+    }
+
+    let parsed = {};
+
+    try {
+      parsed = JSON.parse(data);
+    } catch(e) {
+      return callback(new Error('Unable to parse token data'));
+    }
+
+    if (parsed.hash !== hash) {
+      return callback(new Error('Token not valid for hash'));
+    }
+
+    if (parsed.expires > Date.now()) {
+      return callback(new Error('Token has expired'));
+    }
+
+    let contact = new storj.Contact(parsed.contact);
+
+    callback(null, contact);
+  });
 };
 
 /**
@@ -166,100 +237,104 @@ ShardServer.prototype.routeConsignment = function(req, res) {
   const self = this;
   const hasher = crypto.createHash('sha256');
   const token = req.query.token;
-  const [isAuthed, authError] = this.isAuthorized(
-    token,
-    req.params.hash
-  );
+  const hash = req.params.hash;
 
-  if (!isAuthed) {
-    return res.send(401, { result: authError.message });
-  }
-
-  const {report, contact, hash} = this._allowed[token];
-
-  report.begin(hash);
-
-  // eslint-disable-next-line max-statements
-  this._manager.load(hash, function(err, item) {
+  this.isAuthorized(token, hash, (err, contact) => {
     if (err) {
-      return res.send(404, { result: err.message });
+      res.send(401, { result: err.message });
     }
 
-    const contract = item.getContract(contact);
-    if (!contract) {
-      return res.send(500, { result: 'Unable to locate contract'});
-    }
-    const bridgeExtendedKey = contract.get('renter_hd_key');
-    const bridge = self.farmerInterface.bridges.get(bridgeExtendedKey);
-    if (!bridge) {
-      return res.send(500, { result: 'Not connected to bridge'});
-    }
+    let report: new ExchangeReport({
+      reporterId: this._nodeID,
+      farmerId: this._nodeID
+    })
 
-    const shardsize = contract.get('data_size');
+    report.begin(hash);
 
+    // eslint-disable-next-line max-statements
+    this._manager.load(hash, function(err, item) {
+      if (err) {
+        return res.send(404, { result: err.message });
+      }
 
-    // If the shard is not writable, it means we already have it, so let's
-    // just respond with a success message
-    if (typeof item.shard.write !== 'function') {
-      report.end(ExchangeReport.SUCCESS, 'SHARD_EXISTS');
+      const contract = item.getContract(contact);
+      if (!contract) {
+        return res.send(500, { result: 'Unable to locate contract'});
+      }
+      const bridgeExtendedKey = contract.get('renter_hd_key');
+      const bridge = self.farmerInterface.bridges.get(bridgeExtendedKey);
+      if (!bridge) {
+        return res.send(500, { result: 'Not connected to bridge'});
+      }
 
-      self._sendExchangeReport(bridge.url, report);
-      return res.send(304, { result: 'Consignment completed' });
-    }
+      const shardsize = contract.get('data_size');
 
-    let received = 0;
-
-    self.activeTransfers++;
-    req.on('error', self._handleRequestError.bind(self));
-    res.on('close', self._handleEarlySocketClose.bind(self));
-    req.on('data', function(chunk) {
-      received += chunk.length;
-
-      if (received > shardsize) {
-        report.end(ExchangeReport.FAILURE, 'FAILED_INTEGRITY');
+      // If the shard is not writable, it means we already have it, so let's
+      // just respond with a success message
+      if (typeof item.shard.write !== 'function') {
+        report.end(ExchangeReport.SUCCESS, 'SHARD_EXISTS');
 
         self._sendExchangeReport(bridge.url, report);
+        return res.send(304, { result: 'Consignment completed' });
+      }
 
-        item.shard.destroy(utils.warnOnError(self._log));
+      let received = 0;
+
+      self.activeTransfers++;
+      req.on('error', self._handleRequestError.bind(self));
+      res.on('close', self._handleEarlySocketClose.bind(self));
+      req.on('data', function(chunk) {
+        received += chunk.length;
+
+        if (received > shardsize) {
+          report.end(ExchangeReport.FAILURE, 'FAILED_INTEGRITY');
+
+          self._sendExchangeReport(bridge.url, report);
+
+          item.shard.destroy(utils.warnOnError(self._log));
+          self.activeTransfers--;
+          return res.send(400, {
+            result: 'Shard exceeds the amount defined in the contract'
+          });
+        }
+
+        hasher.update(chunk);
+        item.shard.write(chunk);
+      });
+
+      req.on('end', function() {
+        /* eslint max-statements: [2, 15] */
+        var calculatedHash = utils.rmd160(hasher.digest());
         self.activeTransfers--;
-        return res.send(400, {
-          result: 'Shard exceeds the amount defined in the contract'
-        });
-      }
 
-      hasher.update(chunk);
-      item.shard.write(chunk);
-    });
+        if (calculatedHash !== hash) {
+          report.end(ExchangeReport.FAILURE, 'FAILED_INTEGRITY');
 
-    req.on('end', function() {
-      /* eslint max-statements: [2, 15] */
-      var calculatedHash = utils.rmd160(hasher.digest());
-      self.activeTransfers--;
+          self._sendExchangeReport(bridge.url, report);
 
-      if (calculatedHash !== hash) {
-        report.end(ExchangeReport.FAILURE, 'FAILED_INTEGRITY');
+          self._log.warn('calculated hash does not match the expected result');
+          item.shard.destroy(utils.warnOnError(self._log));
+          return res.send(400, {
+            result: 'Calculated hash does not match the expected result'
+          });
+        }
+
+        self._log.debug('Shard upload completed hash %s', hash);
+        item.shard.end();
+        report.end(ExchangeReport.SUCCESS, 'SHARD_UPLOADED');
 
         self._sendExchangeReport(bridge.url, report);
 
-        self._log.warn('calculated hash does not match the expected result');
-        item.shard.destroy(utils.warnOnError(self._log));
-        return res.send(400, {
-          result: 'Calculated hash does not match the expected result'
-        });
-      }
-
-      self._log.debug('Shard upload completed hash %s', hash);
-      item.shard.end();
-      report.end(ExchangeReport.SUCCESS, 'SHARD_UPLOADED');
-
-      self._sendExchangeReport(bridge.url, report);
-
-      self.reject(req.query.token);
-      res.send(200, { result: 'Consignment completed' });
-      self.emit('shardUploaded', item, contact);
+        self.reject(req.query.token);
+        res.send(200, { result: 'Consignment completed' });
+        self.emit('shardUploaded', item, contact);
+      });
     });
+
   });
+
 };
+
 
 /**
  * Pumps the data through to the client
@@ -268,62 +343,65 @@ ShardServer.prototype.routeConsignment = function(req, res) {
  */
 ShardServer.prototype.routeRetrieval = function(req, res) {
   const self = this;
-  const [isAuthed, authError] = this.isAuthorized(
-    req.query.token,
-    req.params.hash
-  );
+  const token = req.query.token;
+  const hash = req.params.hash;
 
-  if (!isAuthed) {
-    return res.send(401, { result: authError.message });
-  }
-
-  const {report, contact, hash} = this._allowed[req.query.token];
-
-  // eslint-disable-next-line max-statements
-  this._manager.load(hash, function(err, item) {
+  this.isAuthorized(token, hash, (err, contact) => {
     if (err) {
-      return res.send(404, { result: err.message });
+      return res.send(401, { result: err.message });
     }
 
-    const contract = item.getContract(contact);
-    if (!contract) {
-      return res.send(500, { result: 'Unable to locate contract'});
-    }
-    const bridgeExtendedKey = contract.get('renter_hd_key');
-    const bridge = self.farmerInterface.bridges.get(bridgeExtendedKey);
-    if (!bridge) {
-      return res.send(500, { result: 'Not connected to bridge'});
-    }
+    let report: new ExchangeReport({
+      reporterId: this._nodeID,
+      farmerId: this._nodeID
+    })
 
-    function _handleReadFailure(err) {
-      self.activeTransfers--;
-      report.end(ExchangeReport.FAILURE, 'READ_FAILED');
+    // eslint-disable-next-line max-statements
+    this._manager.load(hash, function(err, item) {
+      if (err) {
+        return res.send(404, { result: err.message });
+      }
 
-      self._sendExchangeReport(bridge.url, report);
+      const contract = item.getContract(contact);
+      if (!contract) {
+        return res.send(500, { result: 'Unable to locate contract'});
+      }
+      const bridgeExtendedKey = contract.get('renter_hd_key');
+      const bridge = self.farmerInterface.bridges.get(bridgeExtendedKey);
+      if (!bridge) {
+        return res.send(500, { result: 'Not connected to bridge'});
+      }
 
-      res.send(500, { result: err.message });
-    }
+      function _handleReadFailure(err) {
+        self.activeTransfers--;
+        report.end(ExchangeReport.FAILURE, 'READ_FAILED');
 
-    function _handleTransferFinish() {
-      self.activeTransfers--;
-      self._log.debug('Shard download completed hash %s', item.hash);
-      report.end(ExchangeReport.SUCCESS, 'SHARD_DOWNLOADED');
+        self._sendExchangeReport(bridge.url, report);
 
-      self._sendExchangeReport(bridge.url, report);
+        res.send(500, { result: err.message });
+      }
 
-      self.emit('shardDownloaded', item, contact);
-      self.reject(req.query.token);
-    }
+      function _handleTransferFinish() {
+        self.activeTransfers--;
+        self._log.debug('Shard download completed hash %s', item.hash);
+        report.end(ExchangeReport.SUCCESS, 'SHARD_DOWNLOADED');
 
-    self.activeTransfers++;
-    req.on('error', self._handleRequestError.bind(self));
-    res.on('close', self._handleEarlySocketClose.bind(self));
-    res.header('content-type', 'application/octet-stream');
-    report.begin(hash);
-    item.shard
-      .on('error', _handleReadFailure)
-      .on('end', _handleTransferFinish)
-      .pipe(res);
+        self._sendExchangeReport(bridge.url, report);
+
+        self.emit('shardDownloaded', item, contact);
+        self.reject(req.query.token);
+      }
+
+      self.activeTransfers++;
+      req.on('error', self._handleRequestError.bind(self));
+      res.on('close', self._handleEarlySocketClose.bind(self));
+      res.header('content-type', 'application/octet-stream');
+      report.begin(hash);
+      item.shard
+        .on('error', _handleReadFailure)
+        .on('end', _handleTransferFinish)
+        .pipe(res);
+    });
   });
 };
 
@@ -333,12 +411,29 @@ ShardServer.prototype.routeRetrieval = function(req, res) {
  */
 ShardServer.prototype._reapDeadTokens = function() {
   let now = Date.now();
+  let ops = [];
 
-  for (let token in this._allowed) {
-    if (this._allowed[token].expires < now) {
-      this.reject(token);
-    }
-  }
+  let stream = this._db.createReadStream({
+    lte: 'EX' + Date.now(),
+    gte: 'EX' + 0
+  });
+
+  stream.on('data', (data) => {
+    ops.push({ type: 'del', key: 'TK' + data.value.token });
+    ops.push({ type: 'del', key: 'EX' + data.value.expire });
+  })
+
+  stream.on('error', (err) {
+    this._log.error(err);
+  });
+
+  stream.on('end', () => {
+    this._db.batch(ops, (err) => {
+      if (err) {
+        this._log.error(err);
+      }
+    });
+  });
 };
 
 module.exports = ShardServer;

--- a/lib/network/shard-server.js
+++ b/lib/network/shard-server.js
@@ -7,6 +7,7 @@ const path = require('path');
 const levelup = require('levelup');
 const ExchangeReport = require('../bridge-client/exchange-report');
 const StorageManager = require('../storage/manager');
+const Contact = require('./contact');
 const constants = require('../constants');
 const inherits = require('util').inherits;
 const utils = require('../utils');
@@ -195,11 +196,11 @@ ShardServer.prototype.isAuthorized = function(token, hash, callback) {
       return callback(new Error('Token not valid for hash'));
     }
 
-    if (parsed.expires > Date.now()) {
+    if (parsed.expires < Date.now()) {
       return callback(new Error('Token has expired'));
     }
 
-    let contact = new storj.Contact(parsed.contact);
+    let contact = new Contact(parsed.contact);
 
     callback(null, contact);
   });

--- a/lib/network/shard-server.js
+++ b/lib/network/shard-server.js
@@ -50,7 +50,7 @@ function ShardServer(options) {
     this._reapDeadTokens.bind(this), ShardServer.REAPER_INTERVAL);
 }
 
-ShardServer.TOKEN_EXPIRE = 2592000000;
+ShardServer.TOKEN_EXPIRE = 86400000;
 ShardServer.MAX_OPEN_FILES = 10;
 ShardServer.REAPER_INTERVAL = 60000;
 

--- a/lib/network/shard-server.js
+++ b/lib/network/shard-server.js
@@ -127,7 +127,13 @@ ShardServer.prototype.reject = function(token, callback) {
       return callback(err);
     }
 
-    // TODO get data as json?
+    let parsed = {};
+
+    try {
+      parsed = JSON.parse(data);
+    } catch(err) {
+      return callback(new Error('Unable to parse token data'));
+    }
 
     let ops = [
       { type: 'del', key: 'TK' + data.token },
@@ -419,8 +425,16 @@ ShardServer.prototype._reapDeadTokens = function() {
   });
 
   stream.on('data', (data) => {
-    ops.push({ type: 'del', key: 'TK' + data.value.token });
-    ops.push({ type: 'del', key: 'EX' + data.value.expire });
+    let parsed = {};
+    try {
+      parsed = JSON.parse(data);
+    } catch(err) {
+      this._log.error('Unable to parse data in token reaper');
+      return;
+    }
+
+    ops.push({ type: 'del', key: 'TK' + parsed.token });
+    ops.push({ type: 'del', key: 'EX' + parsed.expire });
   })
 
   stream.on('error', (err) {

--- a/lib/network/shard-server.js
+++ b/lib/network/shard-server.js
@@ -335,6 +335,7 @@ ShardServer.prototype.routeConsignment = function(req, res) {
         self._sendExchangeReport(bridge.url, report);
 
         self.reject(req.query.token);
+
         res.send(200, { result: 'Consignment completed' });
         self.emit('shardUploaded', item, contact);
       });

--- a/lib/network/shard-server.js
+++ b/lib/network/shard-server.js
@@ -124,7 +124,7 @@ ShardServer.prototype.reject = function(token, callback) {
     }
   }
 
-  this._db.get(token, (err, data) => {
+  this._db.get('TK' + token, (err, data) => {
     if (err) {
       return callback(err);
     }
@@ -138,11 +138,11 @@ ShardServer.prototype.reject = function(token, callback) {
     }
 
     let ops = [
-      { type: 'del', key: 'TK' + data.token },
-      { type: 'del', key: 'EX' + data.expire }
+      { type: 'del', key: 'TK' + token },
+      { type: 'del', key: 'EX' + parsed.expires }
     ];
 
-    this._db.del(token, callback);
+    this._db.batch(ops, callback);
   });
 };
 
@@ -436,7 +436,7 @@ ShardServer.prototype._reapDeadTokens = function() {
     }
 
     ops.push({ type: 'del', key: 'TK' + parsed.token });
-    ops.push({ type: 'del', key: 'EX' + parsed.expire });
+    ops.push({ type: 'del', key: 'EX' + parsed.expires });
   })
 
   stream.on('error', (err) => {

--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -81,7 +81,7 @@ Transport.prototype._open = function(callback) {
     maxProxiesAllowed: this._opts.maxTunnels
   });
   this.shardServer = new ShardServer({
-    bridgeClient: this._opts.bridgeClient,
+    storagePath: this._options.storagePath,
     storageManager: this._opts.storageManager,
     logger: this._log,
     nodeID: this._contact.nodeID

--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -79,12 +79,15 @@ Transport.prototype._open = function(callback) {
     proxyMaxConnections: 12,
     maxProxiesAllowed: this._opts.maxTunnels
   });
-  this.shardServer = new ShardServer({
-    storagePath: this._options.storagePath,
-    storageManager: this._opts.storageManager,
-    logger: this._log,
-    nodeID: this._contact.nodeID
-  });
+
+  if (this._opts.storagePath) {
+    this.shardServer = new ShardServer({
+      storagePath: this._opts.storagePath,
+      storageManager: this._opts.storageManager,
+      logger: this._log,
+      nodeID: this._contact.nodeID
+    });
+  }
 
   if (self._doNotTraverseNat) {
     self._isPublic = true; // used to determine tunneling
@@ -157,16 +160,19 @@ Transport.prototype._bindServer = function(callback) {
     restify.bodyParser(),
     self._handleRPC.bind(self)
   );
-  self._server.post(
-    '/shards/:hash',
-    restify.queryParser(),
-    self.shardServer.routeConsignment.bind(self.shardServer)
-  );
-  self._server.get(
-    '/shards/:hash',
-    restify.queryParser(),
-    self.shardServer.routeRetrieval.bind(self.shardServer)
-  );
+
+  if (this._opts.storagePath) {
+    self._server.post(
+      '/shards/:hash',
+      restify.queryParser(),
+      self.shardServer.routeConsignment.bind(self.shardServer)
+    );
+    self._server.get(
+      '/shards/:hash',
+      restify.queryParser(),
+      self.shardServer.routeRetrieval.bind(self.shardServer)
+    );
+  }
 
   const port = self._opts.listenPort ?
     self._opts.listenPort : self._contact.port;

--- a/lib/network/transport.js
+++ b/lib/network/transport.js
@@ -28,7 +28,6 @@ const ShardServer = require('./shard-server');
  * @param {Number}  options.tunnelGatewayRange.max - Max port for gateway bind
  * @param {Number}  options.listenPort - Different port for the server to listen on (optional)
  * @param {StorageManager} options.storageManager
- * @param {BridgeClient} options.bridgeClient
  */
 function Transport(contact, options) {
   if (!(this instanceof Transport)) {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "levelup": "^1.3.1",
     "merge": "^1.2.0",
     "mime": "^1.3.4",
-    "mkdirp": "^0.5.1",
     "ms": "^0.7.1",
     "mtree": "^1.0.0",
     "nat-upnp": "^1.0.2",
@@ -99,7 +98,6 @@
     "readable-stream": "^2.0.6",
     "request": "^2.70.0",
     "restify": "^4.3.0",
-    "rimraf": "^2.5.3",
     "scrypt": "^6.0.3",
     "secp256k1": "^3.2.2",
     "semver": "^5.1.0",
@@ -116,10 +114,12 @@
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.0",
     "memory-blob-store": "^5.0.0",
+    "mkdirp": "^0.5.1",
     "mocha": "^2.2.4",
     "node-mocks-http": "^1.5.4",
     "noisegen": "^1.0.0",
     "proxyquire": "^1.7.3",
+    "rimraf": "^2.6.1",
     "sinon": "^1.14.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "levelup": "^1.3.1",
     "merge": "^1.2.0",
     "mime": "^1.3.4",
+    "mkdirp": "^0.5.1",
     "ms": "^0.7.1",
     "mtree": "^1.0.0",
     "nat-upnp": "^1.0.2",
@@ -98,6 +99,7 @@
     "readable-stream": "^2.0.6",
     "request": "^2.70.0",
     "restify": "^4.3.0",
+    "rimraf": "^2.6.1",
     "scrypt": "^6.0.3",
     "secp256k1": "^3.2.2",
     "semver": "^5.1.0",
@@ -114,12 +116,10 @@
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.0",
     "memory-blob-store": "^5.0.0",
-    "mkdirp": "^0.5.1",
     "mocha": "^2.2.4",
     "node-mocks-http": "^1.5.4",
     "noisegen": "^1.0.0",
     "proxyquire": "^1.7.3",
-    "rimraf": "^2.6.1",
     "sinon": "^1.14.1"
   }
 }

--- a/test/file-handling/file-demuxer.unit.js
+++ b/test/file-handling/file-demuxer.unit.js
@@ -19,7 +19,7 @@ var proxyquire = require('proxyquire');
 describe('FileDemuxer', function() {
 
   before(function(done) {
-    this.timeout(6000);
+    this.timeout(20000);
 
     if (utils.existsSync(TMP_DIR)) {
       rimraf.sync(TMP_DIR);

--- a/test/network/shard-server.unit.js
+++ b/test/network/shard-server.unit.js
@@ -86,7 +86,8 @@ describe('ShardServer', function() {
           expect(parsed.expires);
           expect(parsed.hash);
 
-          server._db.get(server._encodeExpiresKey(2592000000), (err, data) => {
+          let key = server._encodeExpiresKey(ShardServer.TOKEN_EXPIRE);
+          server._db.get(key, (err, data) => {
             if (err) {
               return done(err);
             }

--- a/test/network/shard-server.unit.js
+++ b/test/network/shard-server.unit.js
@@ -788,8 +788,8 @@ describe('ShardServer', function() {
   });
 
   describe('#_reapDeadTokens', function() {
+    this.timeout(0);
     it('should reap dead tokens and leave good ones', function(done) {
-      this.timeout(20000);
       let clock = sandbox.useFakeTimers();
       server = new ShardServer({
         storagePath: tmpPath,
@@ -802,8 +802,8 @@ describe('ShardServer', function() {
         address: '127.0.0.1',
         port: 4001
       };
-      let time = ShardServer.TOKEN_EXPIRE / 50;
-      async.timesSeries(100, (n, next) => {
+      let time = ShardServer.TOKEN_EXPIRE / 12;
+      async.timesSeries(25, (n, next) => {
         server.accept('token' + n, 'hash' + n, contact, (err) => {
           if (err) {
             return next(err);
@@ -817,7 +817,7 @@ describe('ShardServer', function() {
         }
         server._reapDeadTokens();
         server.on('reapedTokens', (total) => {
-          expect(total).to.equal(51);
+          expect(total).to.equal(14);
           server._db.get('TK' + 'token1', (err) => {
             expect(err.notFound).to.equal(true);
             done();

--- a/test/network/shard-server.unit.js
+++ b/test/network/shard-server.unit.js
@@ -789,6 +789,7 @@ describe('ShardServer', function() {
 
   describe('#_reapDeadTokens', function() {
     it('should reap dead tokens and leave good ones', function(done) {
+      this.timeout(20000);
       let clock = sandbox.useFakeTimers();
       server = new ShardServer({
         storagePath: tmpPath,


### PR DESCRIPTION
With SIP6 shard tokens can live longer from `ALLOC` commands. As such it'll be useful for the shard server to be able to persistent shard tokens across node restarts. Shard tokens will still have a TTL, however that TTL can now be much longer e.g. 24 hours. This will also be useful when implementing https://github.com/Storj/bridge/issues/493

**Todo**:
- [ ] Needs integration testing