### PR TITLE
send MIRROR_FAILED instead of FAILED_INTEGRITY

### DIFF
--- a/lib/network/protocol.js
+++ b/lib/network/protocol.js
@@ -398,7 +398,7 @@ Protocol.prototype.handleMirror = function(params, callback) {
       function _onFinish() {
         if (item.hash !== utils.rmd160(hasher256.digest())) {
           self._logger.warn('mirror read integrity check failed, destroying');
-          report.end(ExchangeReport.FAILURE, 'FAILED_INTEGRITY');
+          report.end(ExchangeReport.FAILURE, 'MIRROR_FAILED');
           item.shard.destroy(utils.warnOnError(self._logger));
         } else {
           self._logger.info('successfully mirrored shard hash %s size %s',


### PR DESCRIPTION
* depends on https://github.com/Storj/bridge/pull/537

FAILED_INTEGRITY is used for shard uploads as well and can't be used to trigger a new mirror creation. Switching to MIRROR_FAILED should trigger a new mirror. This should improve the mirror situation.