### PR TITLE
[WIP] Include responseTime and reputation if available

### DIFF
--- a/lib/network/contact.js
+++ b/lib/network/contact.js
@@ -40,6 +40,9 @@ function Contact(options) {
     this.hdIndex = undefined;
   }
 
+  this.reputation = options.reputation;
+  this.responseTime = options.responseTime;
+
   kad.contacts.AddressPortContact.call(this, options);
 }
 

--- a/test/network/contact.unit.js
+++ b/test/network/contact.unit.js
@@ -74,6 +74,22 @@ describe('Network/Contact', function() {
       expect(contact.hdIndex).to.equal(undefined);
     });
 
+    it('should have responseTime and reputation if supplied', function() {
+      var contact = Contact({
+        address: '127.0.0.1',
+        port: 1337,
+        nodeID: '1261d3f171c23169c893a21be1f03bacafad26d7',
+        responseTime: 600,
+        reputation: 4600
+      });
+      expect(contact.responseTime).to.equal(600);
+      expect(contact.reputation).to.equal(4600);
+
+      var contact2json = JSON.parse(JSON.stringify(contact));
+      expect(contact2json.responseTime).to.equal(600);
+      expect(contact2json.reputation).to.equal(4600);
+    });
+
   });
 
 });


### PR DESCRIPTION
This is a quick fix until we deal with the high levels of software entropy that has accumulated.

There are two models for a "Contact" one that exists here in lib/network/contact, and another one is lib/models/contact of MongoDB models. The two come into confusion at: https://github.com/Storj/service-storage-models/blob/master/lib/models/contact.js#L90 where this one is passed into the MongoDB models version, which often lacks all the properties, making it near impossible to set a default value, without inadvertently reseting the value.