### PR TITLE
bugfix invalid private key length

### DIFF
--- a/lib/crypto-tools/keypair.js
+++ b/lib/crypto-tools/keypair.js
@@ -84,7 +84,8 @@ KeyPair.prototype.sign = function(message, options) {
 
   if (opts.compact) {
     var hash = Message(message).magicHash();
-    signobj = secp256k1.sign(hash, this._privkey.toBuffer());
+    signobj = secp256k1.sign(hash,
+      new Buffer(this.getPrivateKeyPadded(), 'hex'));
     sign = bitcore.crypto.Signature.fromDER(
       secp256k1.signatureExport(signobj.signature)
     ).toCompact(signobj.recovery, this._pubkey.compressed).toString('base64');
@@ -93,7 +94,8 @@ KeyPair.prototype.sign = function(message, options) {
       message = new Buffer(message, 'utf8');
     }
     var hash = crypto.createHash('sha256').update(message).digest()
-    signobj = secp256k1.sign(hash, this._privkey.toBuffer());
+    signobj = secp256k1.sign(hash,
+      new Buffer(this.getPrivateKeyPadded(), 'hex'));
     sign = secp256k1.signatureExport(signobj.signature).toString('hex');
   }
 


### PR DESCRIPTION
Bugfix for private key with leading zeros

```
RangeError: private key length is invalid
    at KeyPair.sign (/storj/node_modules/storj-lib/lib/crypto-tools/keypair.js:87:25)
```