### PR TITLE
sign and verify contracts with secp256k1

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -116,6 +116,11 @@ function signMessage(deferred) {
   });
 }
 
+function signContract(deferred) {
+  contract1.sign('renter', renterPrivateKey);
+  deferred.resolve();
+}
+
 suite.add('new hd contract', newHDContract, {maxTime: maxTime});
 suite.add('new contract', newContract, {maxTime: maxTime});
 suite.add('verify message with hd contact', verifyHDContact, {
@@ -127,6 +132,10 @@ suite.add('verify message with contact', verifyContact, {
   defer: true
 });
 suite.add('sign message', signMessage, {
+  maxTime: maxTime,
+  defer: true
+});
+suite.add('sign contract', signContract, {
   maxTime: maxTime,
   defer: true
 });

--- a/bench/index.js
+++ b/bench/index.js
@@ -121,6 +121,11 @@ function signContract(deferred) {
   deferred.resolve();
 }
 
+function verifyContract(deferred) {
+  contract1.verify('renter', renterID);
+  deferred.resolve();
+}
+
 suite.add('new hd contract', newHDContract, {maxTime: maxTime});
 suite.add('new contract', newContract, {maxTime: maxTime});
 suite.add('verify message with hd contact', verifyHDContact, {
@@ -136,6 +141,10 @@ suite.add('sign message', signMessage, {
   defer: true
 });
 suite.add('sign contract', signContract, {
+  maxTime: maxTime,
+  defer: true
+});
+suite.add('verify contract', verifyContract, {
   maxTime: maxTime,
   defer: true
 });

--- a/lib/contract/index.js
+++ b/lib/contract/index.js
@@ -283,14 +283,19 @@ Contract.prototype.verifyExternal = function(signature, pubkeyhash) {
     return false;
   }
 
-  var message = Message(this.getSigningData());
-  var address = bitcore.Address.fromPublicKeyHash(Buffer(pubkeyhash, 'hex'));
-
+  var magic = Message(this.getSigningData()).magicHash();
+  
   try {
-    return message.verify(address, signature);
+    var signobj = bitcore.crypto.Signature.fromCompact(
+      new Buffer(signature, 'base64'));
+    var sig = secp256k1.signatureImport(signobj.toBuffer());
+    var recovery = signobj.i;
+    var pubKey = secp256k1.recover(magic, sig, recovery, true);
   } catch (err) {
     return false;
   }
+  return secp256k1.verify(magic, sig, pubKey) &&
+    bitcore.crypto.Hash.sha256ripemd160(pubKey).toString('hex') === pubkeyhash;
 };
 
 /**

--- a/lib/contract/index.js
+++ b/lib/contract/index.js
@@ -7,6 +7,7 @@ const JSONSchema = require('jsen');
 const stringify = require('json-stable-stringify');
 const bitcore = require('bitcore-lib');
 const constants = require('../constants');
+const KeyPair = require('../crypto-tools/keypair');
 const secp256k1 = require('secp256k1');
 const Message = require('bitcore-message');
 const ms = require('ms');
@@ -259,15 +260,15 @@ Contract.prototype.verify = function(actor, pubkeyhash) {
  * @returns {String} externalSignature
  */
 Contract.prototype.signExternal = function(secret) {
-  var keypair = bitcore.PrivateKey.fromString(secret);
+  var keypair = KeyPair(secret);
   var hash = Message(this.getSigningData()).magicHash();
   var signobj = secp256k1.sign(hash,
-    keypair.toBuffer());
+    new Buffer (keypair.getPrivateKeyPadded(), 'hex'));
   var sign = bitcore.crypto.Signature.fromDER(
     secp256k1.signatureExport(signobj.signature)
   ).toCompact(
     signobj.recovery, 
-    keypair.toPublicKey().compressed
+    keypair.getPublicKey.compressed
   ).toString('base64');
   return sign;
 };

--- a/lib/contract/index.js
+++ b/lib/contract/index.js
@@ -1,14 +1,15 @@
 'use strict';
 
-var assert = require('assert');
-var crypto = require('crypto');
-var merge = require('merge');
-var JSONSchema = require('jsen');
-var stringify = require('json-stable-stringify');
-var bitcore = require('bitcore-lib');
-var constants = require('../constants');
-var Message = require('bitcore-message');
-var ms = require('ms');
+const assert = require('assert');
+const crypto = require('crypto');
+const merge = require('merge');
+const JSONSchema = require('jsen');
+const stringify = require('json-stable-stringify');
+const bitcore = require('bitcore-lib');
+const constants = require('../constants');
+const secp256k1 = require('secp256k1');
+const Message = require('bitcore-message');
+const ms = require('ms');
 
 /**
  * Represents a storage contract between a renter and a farmer
@@ -258,8 +259,17 @@ Contract.prototype.verify = function(actor, pubkeyhash) {
  * @returns {String} externalSignature
  */
 Contract.prototype.signExternal = function(secret) {
-  var message = Message(this.getSigningData());
-  return message.sign(bitcore.PrivateKey.fromString(secret));
+  var keypair = bitcore.PrivateKey.fromString(secret);
+  var hash = Message(this.getSigningData()).magicHash();
+  var signobj = secp256k1.sign(hash,
+    keypair.toBuffer());
+  var sign = bitcore.crypto.Signature.fromDER(
+    secp256k1.signatureExport(signobj.signature)
+  ).toCompact(
+    signobj.recovery, 
+    keypair.toPublicKey().compressed
+  ).toString('base64');
+  return sign;
 };
 
 /**

--- a/test/contract/index.unit.js
+++ b/test/contract/index.unit.js
@@ -259,7 +259,8 @@ describe('Contract (private)', function() {
 
     it('should return true if fields are not null', function() {
       var kp1 = KeyPair();
-      var kp2 = KeyPair();
+      var kp2 = KeyPair(
+        '00008b387bed22aff9ca560416d7b13ecbad16f28bc41ef5acaff3019bfa5134');
       var contract = new Contract({
         renter_id: kp1.getNodeID(),
         farmer_id: kp2.getNodeID(),


### PR DESCRIPTION
For a better performance on the bridge side on sending ALLOC and renew contracts.

- [x] sign contract
- [X] benchmark test sign contracts
old: `sign contract x 16.83 ops/sec ±5.17% (80 runs sampled)`
new: `sign contract x 122 ops/sec ±1.54% (141 runs sampled)`
- [x] verify contracts
- [x] benachmark test verify contracts
old: `verify contract x 21.87 ops/sec ±1.33% (98 runs sampled)`
new: `verify contract x 632 ops/sec ±0.81% (147 runs sampled)`
- [x] unit test private key padding